### PR TITLE
Publish azd catalog metadata

### DIFF
--- a/.azd/catalog.json
+++ b/.azd/catalog.json
@@ -1,0 +1,27 @@
+{
+  "title": "Emergency access protection",
+  "summary": "Continuously ensures the emergency-access group remains excluded from every Microsoft Entra Conditional Access policy.",
+  "tags": [
+    "Entra ID",
+    "Conditional Access",
+    "Emergency Access",
+    "Managed Identity",
+    "Microsoft Sentinel"
+  ],
+  "highlights": [
+    "Choose from four remediation modes: Azure Automation, scheduled Azure Functions, Logic Apps, or Microsoft Sentinel-triggered Functions.",
+    "Uses managed identity throughout, with no stored credentials or client secrets.",
+    "Deploys exactly one remediation mode per azd environment to prevent overlapping remediators."
+  ],
+  "featured": true,
+  "solutionCount": 4,
+  "quickstartCommands": [
+    "azd init --template nathanmcnulty/azd-emergency-access",
+    "azd env new emergency-protection",
+    "azd env set AZD_DEPLOYMENT_MODE function-scheduled",
+    "azd env set AZD_NON_INTERACTIVE true",
+    "azd env set AZD_EMERGENCY_DOMAIN contoso.onmicrosoft.com",
+    "azd provision --preview",
+    "azd up"
+  ]
+}

--- a/.github/workflows/publish-azd-catalog.yml
+++ b/.github/workflows/publish-azd-catalog.yml
@@ -1,0 +1,39 @@
+name: Publish azd catalog metadata
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - .azd/catalog.json
+      - azure.yaml
+      - README.md
+      - .github/workflows/publish-azd-catalog.yml
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  notify-catalog:
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.AZD_CATALOG_TOKEN }}
+    steps:
+      - name: Skip when catalog token is not configured
+        if: env.GH_TOKEN == ''
+        run: echo "::notice title=Catalog dispatch skipped::AZD_CATALOG_TOKEN is not configured for this repository."
+
+      - name: Notify azd website
+        if: env.GH_TOKEN != ''
+        env:
+          SOURCE_REPOSITORY: ${{ github.repository }}
+          SOURCE_REF: ${{ github.ref }}
+        run: |
+          gh api --method POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            /repos/nathanmcnulty/azd-website/dispatches \
+            -f event_type=azd-catalog-updated \
+            -f "client_payload[repository]=$SOURCE_REPOSITORY" \
+            -f "client_payload[ref]=$SOURCE_REF" \
+            -f "client_payload[catalogPath]=.azd/catalog.json"

--- a/README.md
+++ b/README.md
@@ -34,11 +34,15 @@ Initialize and select an environment:
 azd init --template nathanmcnulty/azd-emergency-access
 azd env new emergency-protection
 azd env set AZD_DEPLOYMENT_MODE function-scheduled
+azd env set AZD_NON_INTERACTIVE true
 azd env set AZD_EMERGENCY_DOMAIN contoso.onmicrosoft.com
+azd provision --preview
 azd up
 ```
 
-`azd provision --preview` is recommended before `azd up`, especially in production tenants:
+The quickstart selects the scheduled Function mode as the recommended general-purpose option and disables prompts after setting every required value. Review the preview before approving production tenant changes. For interactive mode selection, omit `AZD_NON_INTERACTIVE` and `AZD_DEPLOYMENT_MODE`.
+
+To preview later infrastructure changes before applying them:
 
 ```powershell
 azd provision --preview
@@ -211,6 +215,12 @@ azd config show
 ## CI and noninteractive use
 
 Set `AZD_NON_INTERACTIVE=true`, provide the mode and all mode-specific values, and authenticate Azure CLI/azd using workload identity federation. Tenant bootstrap requires a Microsoft Graph token with the documented application/delegated permissions; do not use a client secret. TAP remains off unless explicitly enabled. If enabled noninteractively, the policy is configured but TAP methods are not generated because their one-time values cannot be safely delivered through CI; create them interactively afterward.
+
+## azd catalog publishing
+
+The repository-owned website metadata is in [`.azd/catalog.json`](.azd/catalog.json). Changes to that file or its catalog inputs on `main` trigger [the catalog publishing workflow](.github/workflows/publish-azd-catalog.yml), which sends an `azd-catalog-updated` repository dispatch to `nathanmcnulty/azd-website`. Maintainers can also run the workflow manually.
+
+Configure the `AZD_CATALOG_TOKEN` repository Actions secret with a fine-grained personal access token that can send repository dispatches to `nathanmcnulty/azd-website` (repository **Contents: Read and write**). When the secret is absent, the workflow succeeds without dispatching and emits a clear notice.
 
 ## Cleanup
 


### PR DESCRIPTION
## Summary

- add repository-owned azd website metadata at `.azd/catalog.json`
- publish catalog changes to `nathanmcnulty/azd-website` with the `azd-catalog-updated` repository dispatch contract
- document the recommended noninteractive scheduled Function quickstart and `AZD_CATALOG_TOKEN` setup

## Dispatch contract

```json
{
  "event_type": "azd-catalog-updated",
  "client_payload": {
    "repository": "nathanmcnulty/azd-emergency-access",
    "ref": "refs/heads/main",
    "catalogPath": ".azd/catalog.json"
  }
}
```

The workflow emits a notice and succeeds without dispatching when `AZD_CATALOG_TOKEN` is not configured. It can also be run manually.

## Validation

- 24 Pester tests passed
- `az bicep build --file infra/main.bicep`
- `azd config show`
- catalog JSON schema checks
- GitHub Actions YAML parsing

## Coordination

Do not merge until the corresponding `nathanmcnulty/azd-website` consumer PR is ready.