### PR TITLE
Harden generated template and delivery validation

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -43,5 +43,8 @@ jobs:
             exit 1
           }
 
-      - name: Build Bicep
-        run: az bicep build --file infra/main.bicep
+      - name: Build Bicep and verify the generated ARM template
+        run: |
+          az bicep install --version v0.42.1
+          az bicep build --file infra/main.bicep
+          git diff --exit-code -- infra/main.json

--- a/infra/main.json
+++ b/infra/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.42.1.51946",
-      "templateHash": "2911750453733872634"
+      "templateHash": "15167874362435935092"
     }
   },
   "parameters": {
@@ -130,7 +130,7 @@
     },
     "sentinelTeamsDeliveryMode": {
       "type": "string",
-      "defaultValue": "workflow-webhook",
+      "defaultValue": "admin-configured",
       "allowedValues": [
         "workflow-webhook",
         "api-connection",

--- a/scripts/Test-Deployment.ps1
+++ b/scripts/Test-Deployment.ps1
@@ -44,7 +44,7 @@ function Test-SentinelNotificationDelivery {
         throw 'Unable to obtain the Sentinel notification playbook trigger callback for delivery testing.'
     }
 
-    $startedUtc = [DateTimeOffset]::UtcNow
+    $trackingId = [guid]::NewGuid().ToString()
     $payload = @{
         object = @{
             id = "$PlaybookResourceId/providers/Microsoft.SecurityInsights/incidents/delivery-smoke-test"
@@ -62,7 +62,12 @@ function Test-SentinelNotificationDelivery {
     } | ConvertTo-Json -Depth 8 -Compress
 
     try {
-        $response = Invoke-WebRequest -Method Post -Uri $callback.value -ContentType 'application/json' -Body $payload
+        $response = Invoke-WebRequest `
+            -Method Post `
+            -Uri $callback.value `
+            -ContentType 'application/json' `
+            -Headers @{ 'x-ms-client-tracking-id' = $trackingId } `
+            -Body $payload
     }
     catch {
         throw "The Sentinel notification playbook rejected the delivery smoke test. $($_.Exception.Message)"
@@ -84,14 +89,13 @@ function Test-SentinelNotificationDelivery {
             throw 'Unable to inspect the Sentinel notification playbook smoke-test run.'
         }
         $run = @($runs.value) |
-            Where-Object { [DateTimeOffset]$_.properties.startTime -ge $startedUtc.AddSeconds(-2) } |
-            Sort-Object { [DateTimeOffset]$_.properties.startTime } -Descending |
+            Where-Object { $_.properties.correlation.clientTrackingId -eq $trackingId } |
             Select-Object -First 1
     } while ((-not $run -or $run.properties.status -in 'Running', 'Waiting') -and
         [DateTimeOffset]::UtcNow -lt $deadline)
 
     if (-not $run) {
-        throw 'No Sentinel notification playbook run appeared within 60 seconds.'
+        throw "No Sentinel notification playbook run with tracking ID '$trackingId' appeared within 60 seconds."
     }
     if ($run.properties.status -ne 'Succeeded') {
         $actions = & az rest `

--- a/tests/EmergencyAccess.Remediation.Tests.ps1
+++ b/tests/EmergencyAccess.Remediation.Tests.ps1
@@ -15,6 +15,15 @@ Describe 'Invoke-EmergencyAccessRemediation' {
             Invoke-EmergencyAccessRemediation -EmergencyAccountsGroupObjectId nope `
                 -SkipManagedIdentityConnection
         } | Should -Throw '*valid Microsoft Entra object ID*'
+        Should -Invoke Invoke-MgGraphRequest -ModuleName EmergencyAccess.Remediation -Times 0
+    }
+
+    It 'rejects an invalid targeted policy ID before calling Graph' {
+        {
+            Invoke-EmergencyAccessRemediation -EmergencyAccountsGroupObjectId $groupId `
+                -CAPolicyId nope -SkipManagedIdentityConnection
+        } | Should -Throw '*valid Microsoft Entra object ID*'
+        Should -Invoke Invoke-MgGraphRequest -ModuleName EmergencyAccess.Remediation -Times 0
     }
 
     It 'adds the group when exclusions are null' {
@@ -154,15 +163,21 @@ Describe 'Invoke-EmergencyAccessRemediation' {
             -ParameterFilter { $Method -eq 'GET' -and $Uri.ToString().EndsWith($policy1) }
     }
 
-    It 'returns structured failure data through the thrown exception' {
+    It 'continues after a policy failure and returns structured failure data through the thrown exception' {
         Mock Invoke-MgGraphRequest -ModuleName EmergencyAccess.Remediation -ParameterFilter {
             $Method -eq 'GET'
         } -MockWith {
-            @{ value = @(@{ id = $policy1; conditions = @{ users = @{ excludeGroups = @() } } }) }
+            @{ value = @(
+                @{ id = $policy1; conditions = @{ users = @{ excludeGroups = @() } } },
+                @{ id = $policy2; conditions = @{ users = @{ excludeGroups = @() } } }
+            ) }
         }
         Mock Invoke-MgGraphRequest -ModuleName EmergencyAccess.Remediation -ParameterFilter {
-            $Method -eq 'PATCH'
+            $Method -eq 'PATCH' -and $Uri.ToString().EndsWith($policy1)
         } -MockWith { throw 'Graph denied the update' }
+        Mock Invoke-MgGraphRequest -ModuleName EmergencyAccess.Remediation -ParameterFilter {
+            $Method -eq 'PATCH' -and $Uri.ToString().EndsWith($policy2)
+        }
 
         try {
             Invoke-EmergencyAccessRemediation -EmergencyAccountsGroupObjectId $groupId `
@@ -170,8 +185,13 @@ Describe 'Invoke-EmergencyAccessRemediation' {
             throw 'Expected remediation to fail.'
         }
         catch {
+            $_.Exception.Data['Result'].policiesEvaluated | Should -Be 2
+            $_.Exception.Data['Result'].policiesUpdated | Should -Be 1
             $_.Exception.Data['Result'].policiesFailed | Should -Be 1
             $_.Exception.Data['Result'].failed[0].error | Should -Match 'Graph denied'
+            $_.Exception.Data['Result'].updatedPolicyIds | Should -Contain $policy2
         }
+        Should -Invoke Invoke-MgGraphRequest -ModuleName EmergencyAccess.Remediation -Times 2 `
+            -ParameterFilter { $Method -eq 'PATCH' }
     }
 }

--- a/tests/Lifecycle.Wiring.Tests.ps1
+++ b/tests/Lifecycle.Wiring.Tests.ps1
@@ -112,6 +112,9 @@ Describe 'Lifecycle security wiring' {
         $testDeployment | Should -Match 'Test-SentinelNotificationDelivery'
         $testDeployment | Should -Match 'listCallbackUrl\?api-version=2019-05-01'
         $testDeployment | Should -Match '\[TEST\] Emergency access notification delivery validation'
+        $testDeployment | Should -Match ([regex]::Escape("-Headers @{ 'x-ms-client-tracking-id' = `$trackingId }"))
+        $testDeployment | Should -Match 'properties\.correlation\.clientTrackingId -eq \$trackingId'
+        $testDeployment | Should -Not -Match 'startTime -ge \$startedUtc'
         $testDeployment | Should -Match "status -ne 'Succeeded'"
     }
 

--- a/tests/Sentinel.Activity.Alert.Tests.ps1
+++ b/tests/Sentinel.Activity.Alert.Tests.ps1
@@ -1,6 +1,7 @@
 Describe 'Optional Sentinel emergency activity alerting' {
     BeforeAll {
         $main = Get-Content "$PSScriptRoot\..\infra\main.bicep" -Raw
+        $compiledMain = Get-Content "$PSScriptRoot\..\infra\main.json" -Raw | ConvertFrom-Json
         $parameters = Get-Content "$PSScriptRoot\..\infra\main.parameters.json" -Raw
         $alerting = Get-Content "$PSScriptRoot\..\infra\modules\sentinel-activity-alerting.bicep" -Raw
         $rules = Get-Content "$PSScriptRoot\..\infra\modules\sentinel-activity-rules.bicep" -Raw
@@ -8,6 +9,7 @@ Describe 'Optional Sentinel emergency activity alerting' {
         $preProvision = Get-Content "$PSScriptRoot\..\scripts\Pre-Provision.ps1" -Raw
         $postProvision = Get-Content "$PSScriptRoot\..\scripts\Post-Provision.ps1" -Raw
         $preDown = Get-Content "$PSScriptRoot\..\scripts\Pre-Down.ps1" -Raw
+        $validateWorkflow = Get-Content "$PSScriptRoot\..\.github\workflows\validate.yml" -Raw
     }
 
     It 'is independently opt-in and keeps the Teams webhook secret' {
@@ -48,12 +50,19 @@ Describe 'Optional Sentinel emergency activity alerting' {
 
     It 'supports an authorized Teams API connection as an alternative to a webhook' {
         $main | Should -Match "param sentinelTeamsDeliveryMode string = 'admin-configured'"
+        $compiledMain.parameters.sentinelTeamsDeliveryMode.defaultValue | Should -Be 'admin-configured'
         $parameters | Should -Match 'AZD_SENTINEL_TEAMS_CONNECTION_RESOURCE_ID='
         $alerting | Should -Match "teamsDeliveryMode == 'api-connection'"
         $alerting | Should -Match "Post_message_to_Teams_channel"
         $alerting | Should -Match '/beta/teams/conversation/message/poster/'
         $validate | Should -Match 'The Teams API connection is not authorized'
         $validate | Should -Match 'Teams API connection inputs must be empty when workflow-webhook delivery is selected'
+    }
+
+    It 'fails validation when the checked-in ARM template differs from compiled Bicep' {
+        $validateWorkflow | Should -Match 'az bicep install --version v0.42.1'
+        $validateWorkflow | Should -Match 'az bicep build --file infra/main.bicep'
+        $validateWorkflow | Should -Match 'git diff --exit-code -- infra/main.json'
     }
 
     It 'guides an administrator through one browser authorization' {


### PR DESCRIPTION
## Summary
- regenerate the checked-in ARM template and fail CI on Bicep/JSON drift
- correlate Sentinel notification smoke tests to the exact Logic App run using a client tracking ID
- preserve two useful remediation guard tests identified while triaging the older alternative implementation

## Validation
- 43/43 Pester tests pass
- PowerShell and Function JSON parsing pass
- Bicep 0.42.1 rebuild is byte-stable with the checked-in ARM template
- git diff --check passes