### PR TITLE
Improve emergency access administrator onboarding

### DIFF
--- a/.azd/catalog.json
+++ b/.azd/catalog.json
@@ -1,6 +1,6 @@
 {
   "title": "Emergency access protection",
-  "summary": "Continuously ensures the emergency-access group remains excluded from every Microsoft Entra Conditional Access policy.",
+  "summary": "Guides administrators through emergency-account creation, Conditional Access protection, passkey onboarding, and use notifications.",
   "tags": [
     "Entra ID",
     "Conditional Access",
@@ -9,7 +9,8 @@
     "Microsoft Sentinel"
   ],
   "highlights": [
-    "Choose from four remediation modes: Azure Automation, scheduled Azure Functions, Logic Apps, or Microsoft Sentinel-triggered Functions.",
+    "Walk through a first-run administrator wizard with a recommended deployment path.",
+    "Alert by Azure Monitor email and Microsoft Sentinel with Teams delivery.",
     "Uses managed identity throughout, with no stored credentials or client secrets.",
     "Deploys exactly one remediation mode per azd environment to prevent overlapping remediators."
   ],
@@ -17,11 +18,6 @@
   "solutionCount": 4,
   "quickstartCommands": [
     "azd init --template nathanmcnulty/azd-emergency-access",
-    "azd env new emergency-protection",
-    "azd env set AZD_DEPLOYMENT_MODE function-scheduled",
-    "azd env set AZD_NON_INTERACTIVE true",
-    "azd env set AZD_EMERGENCY_DOMAIN contoso.onmicrosoft.com",
-    "azd provision --preview",
     "azd up"
   ]
 }

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+*.bicep text eol=lf
+*.json text eol=lf
+*.md text eol=lf
+*.ps1 text eol=lf
+*.psm1 text eol=lf
+*.yml text eol=lf
+*.yaml text eol=lf

--- a/README.md
+++ b/README.md
@@ -1,439 +1,125 @@
 # Emergency access protection for Microsoft Entra
 
-An [Azure Developer CLI](https://learn.microsoft.com/azure/developer/azure-developer-cli/) template that keeps a designated emergency-access group excluded from every Microsoft Entra Conditional Access policy. One azd environment deploys exactly one remediation mode.
+Deploy and protect two Microsoft Entra emergency access accounts with a guided Azure Developer CLI experience.
 
-> Emergency access is a last-resort control, not a substitute for tested identity recovery procedures. Follow Microsoft's [emergency access account guidance](https://learn.microsoft.com/entra/identity/role-based-access-control/security-emergency-access), monitor every sign-in, and validate these accounts regularly.
+This template helps an administrator:
 
-## Deployment modes
+1. Create or reuse two cloud-only emergency accounts.
+2. Place them in a dedicated group and assign Global Administrator when requested.
+3. Keep that group excluded from every Conditional Access policy.
+4. Alert by email, Microsoft Sentinel, and Microsoft Teams when the accounts are used.
+5. Onboard phishing-resistant passkeys with Temporary Access Pass (TAP).
 
-An azd environment is locked to its first successfully provisioned mode. Use a separate azd environment for each deployment mode. If an environment must be repurposed, run `azd down` successfully before changing `AZD_DEPLOYMENT_MODE`; never change the mode in place, because incremental ARM deployments can leave the previous remediator active.
-
-| `AZD_DEPLOYMENT_MODE` | Trigger | Work performed | Best fit |
-| --- | --- | --- | --- |
-| `automation-scheduled` | Azure Automation schedule | Enumerates all Conditional Access policies | PowerShell-oriented operations |
-| `function-scheduled` | Azure Functions timer | Enumerates all Conditional Access policies | Serverless scheduled enforcement |
-| `logicapp-scheduled` | Consumption Logic App recurrence | Enumerates all Conditional Access policies | Low-code operations |
-| `sentinel-function` | Sentinel NRT alert and automation rule | Remediates only the changed policy | Tenants already ingesting Entra audit logs into Sentinel |
-
-All Graph access uses managed identity. The template does not create a Key Vault, persist credentials, use storage account keys for Function runtime access, or expose Function keys. Optional sign-in alerting uses Azure Monitor and has no access to Microsoft Graph credentials.
+> Emergency access accounts are a last-resort control. Follow [Microsoft's emergency access guidance](https://learn.microsoft.com/entra/identity/role-based-access-control/security-emergency-access), protect the credentials and devices, and test the complete recovery process regularly.
 
 ## Quickstart
 
-### Prerequisites
+### Before you begin
 
-- An Azure subscription and Microsoft Entra tenant.
-- [Azure Developer CLI](https://learn.microsoft.com/azure/developer/azure-developer-cli/install-azd), Azure CLI, PowerShell 7.4 or later, and Azure Functions Core Tools v4 for Function modes.
-- Subscription Contributor plus User Access Administrator or Owner for Azure resources and role assignments.
-- Microsoft Entra Global Administrator or Privileged Role Administrator for permanent Global Administrator assignments.
-- Microsoft Graph delegated consent sufficient to create/read the selected tenant objects and assign Graph app roles. TAP configuration also requires authentication-method policy and user-authentication-method permissions.
-- For `sentinel-function`, an existing Log Analytics workspace with Microsoft Sentinel enabled and Entra `AuditLogs` ingestion.
-- For optional Azure Monitor sign-in alerting, an existing Log Analytics workspace receiving the tenant's Entra `SigninLogs` and an email address for notifications.
-- For optional Sentinel activity alerting, an existing Sentinel-enabled workspace receiving both `SigninLogs` and `AuditLogs`, plus either a Microsoft Teams Workflow webhook or an authorized Teams Logic Apps API connection. Optional playbook email requires an existing authorized Office 365 Outlook Logic Apps connection in the deployment region.
-- A workspace may be in another subscription, but it must be in the same Entra tenant and the deployer must have the required read, deployment, and role-assignment permissions in that subscription and workspace resource group.
+Install:
 
-Initialize and select an environment:
+- [Azure Developer CLI](https://learn.microsoft.com/azure/developer/azure-developer-cli/install-azd)
+- [Azure CLI](https://learn.microsoft.com/cli/azure/install-azure-cli)
+- PowerShell 7.4 or later
+- [Azure Functions Core Tools v4](https://learn.microsoft.com/azure/azure-functions/functions-run-local) for the recommended Function mode
+- Microsoft Graph authentication for PowerShell:
+
+```powershell
+Install-Module Microsoft.Graph.Authentication -Scope CurrentUser
+```
+
+Use an administrator who can deploy Azure resources, create role assignments, prepare the emergency accounts, and grant the Microsoft Graph consent selected by the wizard. See [identity and permissions](docs/identity-and-authentication.md) before using this in production.
+
+Email and Teams alerting require Entra `SigninLogs` and `AuditLogs` to already flow to Log Analytics or Microsoft Sentinel. The wizard lets you configure alerting later if those prerequisites are not ready.
+
+If the administrator is not already signed in, initialize the standard browser-backed caches once:
+
+```powershell
+azd auth login
+az login
+```
+
+### Deploy
+
+Run:
 
 ```powershell
 azd init --template nathanmcnulty/azd-emergency-access
-azd env new emergency-protection
-azd env set AZD_DEPLOYMENT_MODE function-scheduled
-azd env set AZD_NON_INTERACTIVE true
-azd env set AZD_EMERGENCY_DOMAIN contoso.onmicrosoft.com
-azd hooks run preprovision
-azd provision --preview
 azd up
 ```
 
-The quickstart selects the scheduled Function mode as the recommended general-purpose option and disables prompts after setting every required value. A first-run `azd provision --preview` does not execute project hooks, so run the preprovision hook explicitly first when IDs still need to be resolved or created. That hook can create privileged tenant identities and the emergency-access group; review its scope before running it. ARM deployment remains fail-closed if a resolved group ID is absent. Review the infrastructure preview before `azd up`. For interactive mode selection, omit `AZD_NON_INTERACTIVE` and `AZD_DEPLOYMENT_MODE`.
+The first `azd up` walks through:
 
-To preview later infrastructure changes before applying them:
+- the remediation service, with a scheduled Azure Function recommended for most organizations;
+- creating, reusing, or externally managing the emergency identities;
+- optional TAP and passkey onboarding;
+- Azure Monitor email, Sentinel and Teams, both notification paths, or later configuration;
+- normal Azure and Microsoft Graph browser consent.
 
-```powershell
-azd provision --preview
-azd up
-```
+The choices are saved in the azd environment, so rerunning `azd up` is non-destructive and does not repeat a completed setup wizard. An interrupted wizard resumes on the next interactive run. Device-code authentication is never used.
 
-The preprovision hook prompts for a mode when a terminal is interactive. CI and other noninteractive runs must set every required value explicitly.
+### Finish account onboarding
 
-### Reuse existing emergency identities
+If TAP onboarding was selected, each TAP is displayed exactly once. Before closing the terminal:
 
-Each existing object is independent. Supply any combination; only missing objects are created.
+1. Securely give each TAP to its intended custodian.
+2. Sign in as each emergency account and register at least two passkeys.
+3. Test both accounts through the documented recovery procedure.
+4. Confirm the selected email and Teams notifications arrive.
+5. Store credentials and recovery devices separately from normal administrator credentials.
 
-```powershell
-azd env set AZD_EMERGENCY_USER1_ID 11111111-1111-1111-1111-111111111111
-azd env set AZD_EMERGENCY_USER2_UPN emergency2@contoso.onmicrosoft.com
-azd env set AZD_EMERGENCY_GROUP_ID 22222222-2222-2222-2222-222222222222
-azd env set AZD_ADMINISTRATIVE_UNIT_ID 33333333-3333-3333-3333-333333333333
-azd up
-```
+Do not consider the deployment complete until both accounts and the notification path have been tested.
 
-If a user must be created, a cryptographically random initial password is generated only to satisfy Microsoft Graph, then immediately discarded. It is never printed, returned, stored in azd state, written to a file, logged, or placed in Key Vault. **Password recovery/output is intentionally impossible.** Use TAP onboarding to establish passkeys.
-
-### Sentinel mode
-
-```powershell
-azd env set AZD_DEPLOYMENT_MODE sentinel-function
-azd env set AZD_SENTINEL_WORKSPACE_NAME law-security
-azd env set AZD_SENTINEL_WORKSPACE_RESOURCE_GROUP rg-security
-azd env set AZD_SENTINEL_WORKSPACE_SUBSCRIPTION_ID 00000000-0000-0000-0000-000000000000 # optional, same tenant
-azd env set AZD_EMERGENCY_GROUP_ID 22222222-2222-2222-2222-222222222222
-azd hooks run preprovision
-azd provision --preview
-azd up
-```
-
-The workspace must already be Sentinel-enabled. The template deploys an NRT analytics rule, one alert per result, no incidents, an alert-created automation rule, and a minimal Sentinel playbook. The playbook calls the targeted remediation Function through its managed identity. The hook creates a tenant-local API application with the stable `api://<appId>` audience and an `EmergencyAccess.Remediate` application role, then grants that role to the playbook managed identity. App Service Authentication validates that audience and restricts callers to the playbook principal. The Function binding is `anonymous` only so Easy Auth, rather than a Function key, is the sole request authenticator. No client secret is created. Re-run the Sentinel verification flow after changes to Microsoft Sentinel analytics/automation APIs, the Sentinel Logic Apps connector, or the Function authentication configuration.
-
-### Optional emergency sign-in alerts
-
-Enable this capability with any deployment mode when Entra sign-in logs already flow to a Log Analytics workspace:
-
-```powershell
-azd env set AZD_ENABLE_SIGNIN_ALERTS true
-azd env set AZD_SIGNIN_LOG_WORKSPACE_NAME law-security
-azd env set AZD_SIGNIN_LOG_WORKSPACE_RESOURCE_GROUP rg-security
-azd env set AZD_SIGNIN_LOG_WORKSPACE_SUBSCRIPTION_ID 00000000-0000-0000-0000-000000000000 # optional, same tenant
-azd env set AZD_SIGNIN_ALERT_EMAIL identity-operations@contoso.com
-azd hooks run preprovision
-azd provision --preview
-azd up
-```
-
-To leave identity lifecycle entirely with an external process, supply the existing group ID and disable identity management. The template then does not create or modify emergency users, group membership, Global Administrator assignments, the restricted administrative unit, or TAP configuration. Sign-in or Sentinel activity alerting additionally requires both user object IDs. The deployment still grants the selected workload the Microsoft Graph application roles needed to remediate Conditional Access policies; Sentinel Function mode may also create or configure its authentication application.
-
-```powershell
-azd env set AZD_MANAGE_EMERGENCY_IDENTITIES false
-azd env set AZD_EMERGENCY_GROUP_ID 22222222-2222-2222-2222-222222222222
-azd env set AZD_EMERGENCY_USER1_ID 11111111-1111-1111-1111-111111111111 # required with alerting
-azd env set AZD_EMERGENCY_USER2_ID 44444444-4444-4444-4444-444444444444 # required with alerting
-azd up
-```
-
-In `sentinel-function` mode, the sign-in workspace name, resource group, and subscription default to the configured Sentinel workspace, so only the enable flag and email are additional. The workspace must ingest the tenant's `SigninLogs`; this template intentionally does not change tenant diagnostic settings or log retention. Deployment query validation fails closed if the table is unavailable.
-
-The deployment creates a severity-0 Azure Monitor scheduled-query alert and an email action group in the azd environment's resource group. The alert resource uses the workspace's Azure region. Every five minutes, it searches a one-hour event-time range but selects only records ingested during the preceding five minutes; this accommodates normal ingestion delay without repeatedly alerting on the same record. It matches successful or failed sign-in attempts by either resolved emergency-user object ID. Failed attempts are included because they can reveal misuse even when no login succeeds. The rule is stateless (`autoMitigate: false`), so a later evaluation can notify again rather than remaining suppressed behind an unresolved emergency alert. Azure Monitor groups records found in the same evaluation into one alert notification.
-
-### Optional Sentinel activity alerts and Teams notifications
-
-This independent capability works with any remediation mode. It creates three Sentinel NRT analytics rules and an incident-triggered notification playbook:
-
-- Every successful or failed interactive sign-in by either emergency account.
-- Every Entra audit event initiated by either emergency account, preserving the operation, result, service, and correlation ID for investigation.
-- Every Entra audit event that names either emergency account as a target, including credential, role, permission, or account changes made by someone else.
-
-Each matching event creates its own high-severity Sentinel alert and incident. An incident-created automation rule invokes a managed-identity playbook, which posts through the selected Teams delivery method. This keeps SOC incident history and Teams delivery separate from the Azure Monitor action-group path.
-
-The default interactive setup uses a Teams Logic Apps API connection and guides the administrator through its one required browser authorization:
-
-1. In Teams, right-click the destination channel and select **Copy link**.
-2. Run `azd up` and paste that link when prompted. The hook derives the tenant, team, and channel IDs.
-3. The deployment creates the Teams connection and opens Microsoft's authorization page in the normal browser.
-4. Sign in once as the durable notification account that should appear as the message sender, then return to the terminal and press Enter.
-5. The hook verifies the connection, enables the playbook, and the optional delivery smoke test verifies a real channel post.
-
-```powershell
-azd env set AZD_ENABLE_SENTINEL_ACTIVITY_ALERTS true
-azd env set AZD_SENTINEL_WORKSPACE_NAME law-security
-azd env set AZD_SENTINEL_WORKSPACE_RESOURCE_GROUP rg-security
-azd env set AZD_SENTINEL_WORKSPACE_SUBSCRIPTION_ID 00000000-0000-0000-0000-000000000000 # optional, same tenant
-azd hooks run preprovision
-azd provision --preview
-azd up
-```
-
-This is user authorization of the Teams connector, not a tenant-wide Microsoft Graph permission grant. Use a dedicated, durable notification account with access to the destination channel rather than an emergency account or an administrator's everyday identity. The connector posts as that account, and its authorization must be renewed if that account's tokens are revoked.
-
-To send one labeled test notification after deployment and fail `azd up` when the actual Teams or optional Outlook action fails, enable the delivery smoke test. It is off by default so routine deployments do not post messages:
-
-```powershell
-azd env set AZD_TEST_SENTINEL_NOTIFICATION_DELIVERY true
-azd up
-```
-
-An API connection can continue to report `Connected` after its delegated refresh token has been revoked or expired. The live smoke test is the authoritative delivery check; resource status alone is not.
-
-To reuse an existing authorized Teams Logic Apps connection instead of the guided flow, provide the connection and target IDs explicitly. The connection must use the Teams managed API in `AZURE_LOCATION` and the same Azure subscription:
-
-```powershell
-azd env set AZD_SENTINEL_TEAMS_DELIVERY_MODE api-connection
-azd env set AZD_SENTINEL_TEAMS_CONNECTION_RESOURCE_ID '/subscriptions/<subscription>/resourceGroups/<resource-group>/providers/Microsoft.Web/connections/<connection>'
-azd env set AZD_SENTINEL_TEAMS_TEAM_ID '<team ID>'
-azd env set AZD_SENTINEL_TEAMS_CHANNEL_ID '<channel ID>'
-```
-
-For unattended deployment, provide the copied channel link and keep the default `admin-configured` mode. The deployment leaves the playbook disabled and prints the consent URL for a Teams administrator:
-
-```powershell
-azd env set AZD_SENTINEL_TEAMS_DELIVERY_MODE admin-configured
-azd env set AZD_SENTINEL_TEAMS_CHANNEL_LINK '<copied Teams channel link>'
-azd up
-```
-
-An administrator opens the printed consent URL and authorizes the connection, then reruns `azd hooks run postprovision`. No delivery-mode change or second infrastructure deployment is required.
-
-If policy prohibits a user-authorized Azure API connection, `workflow-webhook` remains available. Create a Teams Workflow using **When a Teams webhook request is received**, assign durable owners, add the channel-posting action, and store its callback URL as `AZD_SENTINEL_TEAMS_WEBHOOK_URL`. The playbook calls that URL without acquiring a user token, but the URL is a bearer secret and the Teams Workflow still has an owner lifecycle.
-
-The Sentinel playbook can also send high-importance email through an existing, authorized Office 365 Outlook API connection. Supply both values or neither:
-
-```powershell
-azd env set AZD_SENTINEL_OUTLOOK_CONNECTION_RESOURCE_ID '/subscriptions/<subscription>/resourceGroups/<resource-group>/providers/Microsoft.Web/connections/<connection>'
-azd env set AZD_SENTINEL_NOTIFICATION_EMAIL identity-operations@contoso.com
-```
-
-The connection must be in `AZURE_LOCATION` and report an authorized status. This template deliberately does not create or silently authorize a user-bound Outlook connection. Keep Azure Monitor Action Group email enabled as the simpler independent path; if both paths use the same recipient, that recipient will receive one Azure Monitor message and one Sentinel incident message.
-
-The Sentinel remediation and activity-notification playbooks export `WorkflowRuntime` logs and metrics to an existing workspace: the deployment's operational workspace for Sentinel Function mode and the selected Sentinel workspace for activity notifications. This adds only diagnostic settings—not another workspace or polling service—and gives centralized monitoring the data needed to detect failed or disabled notification runs.
-
-The API-connection option is suitable for an organization that prohibits bearer-style webhook URLs and is demonstrated by `azd-entra-health-monitoring`. It provides an explicit connection resource and channel IDs but adds interactive delegated consent and connection-owner lifecycle. Normal Microsoft Graph channel posting is not a managed-identity substitute because application permission is limited to migration scenarios. A polling Function is intentionally not deployed: once `SigninLogs` and `AuditLogs` are in Sentinel, polling adds checkpoint, overlap, deduplication, retry, and Graph `AuditLog.Read.All` responsibilities without improving detection quality. Consider Event Hub plus a Function only for cross-tenant routing, third-party destinations, or custom correlation that Sentinel and Logic Apps cannot provide.
-
-For a Teams sender with no user OAuth or owner dependency at runtime, use a proactive Teams bot as a separate notification adapter. The bot authenticates as an application, but it must be hosted, published or approved in the tenant app catalog, installed in the target team, and retain the conversation reference needed for proactive messages. That operational cost is substantially higher than the built-in `admin-configured` handoff and is best reserved for tenants with a strict application-identity requirement. Direct Microsoft Graph channel posting is not a shortcut: its application permission is supported only for migration scenarios.
-
-For app-only email, Azure Communication Services Email can send with a managed identity after an Email Communication Services domain and sender are configured. This template keeps Azure Monitor Action Group email as the default because it has no mailbox OAuth connection and no additional mail-domain infrastructure. Add Azure Communication Services only when branded sending, application-controlled content, or centralized app-only delivery justifies that extra service.
-
-## Architecture
-
-### Azure Automation
+## What gets deployed
 
 ```mermaid
 flowchart LR
-  Schedule --> Runbook
-  Runbook -->|managed identity| Graph[Microsoft Graph]
-  Graph --> Policies[All Conditional Access policies]
-  Runbook -->|PATCH missing exclusion| Policies
+  Admin[Administrator] --> Wizard[azd guided setup]
+  Wizard --> Identities[Two emergency accounts and group]
+  Wizard --> Remediator[Conditional Access remediator]
+  Remediator --> Policies[All Conditional Access policies]
+  Signins[SigninLogs and AuditLogs] --> Alerts[Azure Monitor or Sentinel]
+  Alerts --> Email[Email]
+  Alerts --> Teams[Teams channel]
 ```
 
-### Scheduled Function
+Only one remediation mode is deployed per azd environment. All runtime access to Microsoft Graph uses managed identity. The template does not store account passwords, TAP values, client secrets, Function keys, or storage keys.
 
-```mermaid
-flowchart LR
-  Timer --> Function[PowerShell Flex Consumption Function]
-  Function -->|user-assigned managed identity| Graph[Microsoft Graph]
-  Graph --> Policies[All Conditional Access policies]
-  Function --> AppInsights[Application Insights]
-```
+## Choose an alerting path
 
-### Scheduled Logic App
+| Experience | What the administrator receives | Prerequisite |
+| --- | --- | --- |
+| Azure Monitor | Critical email for successful or failed emergency-account sign-ins | `SigninLogs` in Log Analytics |
+| Microsoft Sentinel | Incidents for sign-ins, activity performed by the accounts, and changes to the accounts | `SigninLogs` and `AuditLogs` in Sentinel |
+| Sentinel plus Teams | Sentinel incidents posted to a selected Teams channel | Sentinel prerequisites and one browser authorization |
+| Both | Independent Azure Monitor email and Sentinel/Teams notifications | Both sets of prerequisites |
 
-```mermaid
-flowchart LR
-  Recurrence --> LogicApp[Consumption Logic App]
-  LogicApp -->|system-assigned managed identity| Graph[Microsoft Graph]
-  Graph --> Policies[All Conditional Access policies]
-```
+The guided Teams option asks for a copied Teams channel link, creates the connection, prints one consent link, and enables the playbook after authorization. A webhook and a pre-authorized API connection remain available for advanced environments.
 
-### Sentinel-targeted Function
+## Documentation
 
-```mermaid
-flowchart LR
-  Audit[Entra AuditLogs] --> NRT[Sentinel NRT rule]
-  NRT --> Alert[Alert with CAPolicyId]
-  Alert --> Automation[Alert-created automation rule]
-  Automation --> Playbook[Sentinel Logic App]
-  Playbook -->|managed identity + Entra auth| Function[PowerShell Flex Function]
-  Function -->|managed identity| Policy[Changed CA policy]
-```
-
-### Optional sign-in monitoring
-
-```mermaid
-flowchart LR
-  Signins[Entra SigninLogs] --> Workspace[Existing Log Analytics workspace]
-  Workspace --> Rule[Severity 0 log alert every 5 minutes]
-  Rule --> ActionGroup[Azure Monitor action group]
-  ActionGroup --> Email[Identity operations email]
-```
-
-### Optional Sentinel activity monitoring
-
-```mermaid
-flowchart LR
-  Entra[SigninLogs and AuditLogs] --> NRT[Three Sentinel NRT rules]
-  NRT --> Incident[One incident per event]
-  Incident --> Automation[Incident-created automation rule]
-  Automation --> Playbook[Managed-identity Logic App]
-  Playbook --> Teams[Teams Workflow webhook or API connection]
-  Playbook -. optional .-> Outlook[Authorized Outlook connection]
-```
-
-The NRT query detects successful policy additions/updates, ignores the remediation identity to avoid loops, and exposes `CAPolicyId` as a custom detail:
-
-```kusto
-AuditLogs
-| where Result =~ "success"
-| where OperationName in ("Add conditional access policy", "Update conditional access policy")
-| where Identity != "<remediation identity/name>"
-| extend CAPolicyId = tostring(todynamic(TargetResources)[0].id), ActorIdentity = Identity
-| where isnotempty(CAPolicyId)
-| project TimeGenerated, CAPolicyId, OperationName, ActorIdentity, CorrelationId
-```
-
-## Environment variables
-
-| Variable | Default | Required | Purpose |
-| --- | --- | --- | --- |
-| `AZD_DEPLOYMENT_MODE` | none | Always | One of the four mode names above |
-| `AZURE_LOCATION` | `westus2` | Always | Resource deployment region |
-| `AZD_EMERGENCY_DOMAIN` | none | When creating users | Verified tenant domain used for generated UPNs |
-| `AZD_EMERGENCY_USER1_ID` / `AZD_EMERGENCY_USER2_ID` | none | No | Existing user object IDs |
-| `AZD_EMERGENCY_USER1_UPN` / `AZD_EMERGENCY_USER2_UPN` | none | No | Existing UPNs; resolved IDs are persisted |
-| `AZD_EMERGENCY_GROUP_ID` | none | No | Existing security-group object ID |
-| `AZD_ADMINISTRATIVE_UNIT_ID` | none | No | Existing administrative-unit object ID |
-| `AZD_MANAGE_EMERGENCY_IDENTITIES` | `true` | Always | Set `false` to require externally managed identities and skip user, group, role, AU, and TAP changes |
-| `AZD_USE_RESTRICTED_AU` | `true` | Always | Create/use a restricted management AU; set `false` to skip |
-| `AZD_ENABLE_TAP_POLICY` | `false` | Always | Enable/configure TAP and create reusable TAPs |
-| `AZD_ENABLE_SIGNIN_ALERTS` | `false` | Always | Deploy an optional critical alert for emergency-account sign-in activity |
-| `AZD_SIGNIN_LOG_WORKSPACE_NAME` | Sentinel workspace in Sentinel mode | When alerts enabled | Existing workspace receiving Entra `SigninLogs` |
-| `AZD_SIGNIN_LOG_WORKSPACE_SUBSCRIPTION_ID` | Sentinel workspace subscription or `AZURE_SUBSCRIPTION_ID` | When alerts enabled | Subscription containing the sign-in-log workspace; must belong to `AZURE_TENANT_ID` |
-| `AZD_SIGNIN_LOG_WORKSPACE_RESOURCE_GROUP` | Sentinel workspace resource group in Sentinel mode | When alerts enabled | Resource group containing the sign-in-log workspace |
-| `AZD_SIGNIN_ALERT_EMAIL` | none | When alerts enabled | One plain email address for the deployed action group |
-| `AZD_ENABLE_SENTINEL_ACTIVITY_ALERTS` | `false` | Always | Deploy optional Sentinel sign-in, admin-activity, and account-change detections plus notifications |
-| `AZD_TEST_SENTINEL_NOTIFICATION_DELIVERY` | `false` | With Sentinel activity alerts | Post one labeled test notification after deployment and fail on delivery errors |
-| `AZD_SENTINEL_TEAMS_DELIVERY_MODE` | `admin-configured` | With Sentinel activity alerts | Guided authorization, or `workflow-webhook` / existing `api-connection` alternatives |
-| `AZD_SENTINEL_TEAMS_CHANNEL_LINK` | none | Guided Teams setup | Channel link copied from Teams; team, channel, and tenant IDs are derived |
-| `AZD_SENTINEL_TEAMS_WEBHOOK_URL` | none | Webhook mode | Secret Teams Workflow callback URL for the target channel |
-| `AZD_SENTINEL_TEAMS_CONNECTION_RESOURCE_ID` | none | API-connection mode | Existing authorized Teams Logic Apps connection |
-| `AZD_SENTINEL_TEAMS_TEAM_ID` | none | API-connection mode | Target Microsoft Teams team ID |
-| `AZD_SENTINEL_TEAMS_CHANNEL_ID` | none | API-connection mode | Target Microsoft Teams channel ID |
-| `AZD_SENTINEL_OUTLOOK_CONNECTION_RESOURCE_ID` | none | No | Existing authorized Office 365 Outlook Logic Apps connection for optional playbook email |
-| `AZD_SENTINEL_NOTIFICATION_EMAIL` | none | With Outlook connection | One plain recipient address for Sentinel playbook email |
-| `AZD_SCHEDULE_CRON` | `0 0 */6 * * *` | Function mode | Six-field NCRONTAB timer schedule |
-| `AZD_SCHEDULE_INTERVAL` | `6` | Automation/Logic App | Positive recurrence interval |
-| `AZD_SCHEDULE_FREQUENCY` | `Hour` | Automation/Logic App | `Minute`, `Hour`, `Day`, `Week`, or `Month` |
-| `AZD_AUTOMATION_TIME_ZONE` | `Etc/UTC` | Automation | Automation schedule timezone |
-| `AZD_SENTINEL_WORKSPACE_NAME` | sign-in workspace when available | Sentinel mode or activity alerts | Existing Sentinel workspace |
-| `AZD_SENTINEL_WORKSPACE_SUBSCRIPTION_ID` | sign-in workspace subscription or `AZURE_SUBSCRIPTION_ID` | Sentinel mode or activity alerts | Subscription containing the Sentinel workspace; must belong to `AZURE_TENANT_ID` |
-| `AZD_SENTINEL_WORKSPACE_RESOURCE_GROUP` | sign-in workspace resource group when available | Sentinel mode or activity alerts | Existing workspace resource group |
-| `AZD_FUNCTION_AUTH_CLIENT_ID` | created | Sentinel | Optional existing API app client ID; normally hook-managed |
-| `AZD_FUNCTION_AUTH_AUDIENCE` | `api://<appId>` | Sentinel with existing app | Resolvable API application ID URI |
-| `AZD_RESOURCE_NAME_PREFIX` | environment-derived | No | Optional deterministic naming prefix |
-| `AZD_NON_INTERACTIVE` | `false` | CI | Set `true` to disable prompts |
-
-The deployment records non-secret resolved object IDs and exact `AZD_OWNED_*_ID` ownership records in the azd environment for idempotency and safe cleanup. It refuses to replace an exact-owned privileged object until that object is explicitly cleaned up, preventing an old emergency account or API app from being stranded. Cleanup requires the current configured ID to exactly match the recorded created ID. Passwords and TAP values are never persisted.
-
-## Identity bootstrap and permissions
-
-The preprovision hook resolves the tenant identities needed by ARM configuration, and the postprovision hook grants workload permissions and performs optional TAP onboarding. On the first deployment, standard `Connect-MgGraph` requests the complete delegated scope set needed by the selected capabilities and records `AZD_GRAPH_AUTH_INITIALIZED=true`. Later phases call literal `Connect-MgGraph -NoWelcome`, allowing its current-user MSAL cache to refresh and persist across PowerShell processes without forcing tenant selection or another consent request. If the cached context is missing permissions, the hook stops with the one-time initialization instruction; it does not automatically launch another authentication request. Device-code authentication is not used. The hooks:
-
-1. Resolve or create two cloud-only users.
-2. Resolve or create a security group and add both users.
-3. Create/use a restricted management administrative unit by default and add the users/group.
-4. Assign permanent Global Administrator to both users.
-5. Grant the remediation workload identity `Policy.Read.All`, `Policy.ReadWrite.ConditionalAccess`, and `Application.Read.All`. The last permission is the documented higher-privilege workaround for the current Conditional Access PATCH permissions issue.
-6. Optionally configure TAP and issue reusable two-hour passes.
-
-A restricted management AU limits management by many delegated administrators, but **Global Administrators can still manage restricted objects**. Keep emergency accounts cloud-only, exclude them only as intended, alert on all activity, and separate credentials/devices from ordinary administration.
-
-Sentinel also requires its **Azure Security Insights** automation service identity to have **Microsoft Sentinel Automation Contributor** at the playbook resource-group scope. The postprovision hook assigns this when the tenant service principal is available. If propagation or permissions block it, use **Microsoft Sentinel > Settings > Playbook permissions** to grant access to the resource group printed by the hook.
-
-## TAP and passkey onboarding
-
-When TAP policy enablement is requested, bootstrap merges the emergency group into the existing `includeTargets` collection and leaves exclusions and unrelated policy settings unchanged.
-
-`AZD_ENABLE_TAP_POLICY` defaults to `false`, and deployments do not prompt for TAP onboarding. Set it explicitly to `true` before deployment when the template should change the tenant authentication-method policy and create passes.
-
-When enabled, each reusable TAP has a lifetime of exactly 120 minutes and is displayed once in the interactive console. It is not recoverable from this project. Immediately:
-
-1. Sign in as each emergency user with its TAP.
-2. Register at least two passkeys for each account.
-3. Test each passkey from the documented emergency workstation/process.
-4. Remove obsolete authentication methods according to policy.
-
-Delegated consent can cause HTTP 403 even when the operator is Global Administrator. TAP failures are nonfatal to core Azure provisioning. Grant the required Microsoft Graph delegated permissions/admin consent, enable Temporary Access Pass for the emergency group, manually create a reusable two-hour TAP for each account, and register at least two passkeys per account.
-
-## Remediation behavior and idempotency
-
-The shared PowerShell core validates GUIDs, reads authoritative policy state, preserves and deduplicates all existing `excludeGroups`, and sends PATCH only when the emergency group is missing. Scheduled modes enumerate the policy collection. Sentinel mode retrieves only the supplied `CAPolicyId`. Results include evaluated, updated, unchanged, and failed counts plus policy IDs; any Graph update failure returns structured failure data and a failing invocation.
-
-Rerunning `azd up` reuses tenant IDs persisted in the current azd environment, preserves existing Azure resources, and repeats role/app-role assignments only when absent.
-
-## Verification
-
-1. Create or update a test Conditional Access policy without the emergency group exclusion. Keep it in report-only mode and scope it safely.
-2. Trigger the selected schedule/runbook, or wait for the Sentinel NRT alert.
-3. Confirm the group is appended to `conditions.users.excludeGroups` and all prior exclusions remain.
-4. Run remediation again and confirm zero PATCH operations.
-5. Review Automation jobs, Function logs/Application Insights, Logic App run history, or Sentinel automation-rule runs.
-6. Test both emergency users and both passkeys per user through the documented recovery procedure.
-7. If Azure Monitor sign-in alerts are enabled, confirm the test creates a severity-0 alert and that the action-group email arrives.
-8. If Sentinel activity alerts are enabled, confirm the sign-in produces a high-severity incident, the playbook run succeeds, and its Teams card arrives. Perform a harmless, approved directory change with one test emergency account and confirm the admin-activity rule also fires. Restore the change and preserve the incidents for the drill review.
-9. If playbook email is enabled, verify delivery independently from Action Group email. Treat planned alerts as expected only inside the approved drill window.
-
-Run repository validation:
-
-```powershell
-Invoke-Pester ./tests
-az bicep build --file ./infra/main.bicep
-azd config show
-```
-
-## CI and noninteractive use
-
-Set `AZD_NON_INTERACTIVE=true`, provide the mode and all mode-specific values, and authenticate Azure CLI/azd using workload identity federation. Tenant bootstrap separately uses standard `Connect-MgGraph`; establish a compatible delegated current-user context before the hooks run. Device-code flow and client secrets are not used. TAP remains off unless explicitly enabled. If enabled noninteractively, the policy is configured but TAP methods are not generated because their one-time values cannot be safely delivered through CI; create them interactively afterward.
-
-## azd catalog publishing
-
-The repository-owned website metadata is in [`.azd/catalog.json`](.azd/catalog.json). Changes to that file or its catalog inputs on `main` trigger [the catalog publishing workflow](.github/workflows/publish-azd-catalog.yml), which sends an `azd-catalog-updated` repository dispatch to `nathanmcnulty/azd-website`. Maintainers can also run the workflow manually.
-
-Configure the `AZD_CATALOG_TOKEN` repository Actions secret with a fine-grained personal access token that can send repository dispatches to `nathanmcnulty/azd-website` (repository **Contents: Read and write**). When the secret is absent, the workflow succeeds without dispatching and emits a clear notice.
+| Guide | Use it for |
+| --- | --- |
+| [Deployment modes](docs/deployment-modes.md) | Choosing the remediation service and understanding its architecture |
+| [Identity and authentication](docs/identity-and-authentication.md) | Accounts, permissions, Graph consent, TAP, and passkeys |
+| [Conditional Access remediation](docs/conditional-access-remediation.md) | Policy behavior, safety controls, and idempotency |
+| [Alerting and notifications](docs/alerting-and-notifications.md) | Azure Monitor, Sentinel, email, Teams, and audit coverage |
+| [Configuration reference](docs/configuration.md) | Environment variables, existing identities, and automation |
+| [Operations](docs/operations.md) | Verification, troubleshooting, maintenance, and cleanup |
+| [Development and publishing](docs/development.md) | Repository validation, generated templates, and catalog updates |
 
 ## Cleanup
 
-Delete Azure resources for the active environment:
+Remove Azure resources and exact-owned external Sentinel resources:
 
 ```powershell
 azd down --purge --force
 ```
 
-Before the primary resource group is removed, the noninteractive `predown` hook validates and deletes this environment's exact recorded Sentinel analytics/automation rule IDs and playbook Reader role assignment from the external workspace. It also deletes only the exact environment-owned Function API application/service principal. A supplied API application is never deleted. Failure to validate ownership stops `azd down` rather than broadening deletion.
+Emergency tenant identities are intentionally retained. If this environment created them and deletion is explicitly approved, follow the ownership-aware process in [operations](docs/operations.md#remove-tenant-identities).
 
-Normal Azure cleanup intentionally does not delete emergency tenant identities. To delete only tenant objects whose exact current IDs match exact created-ID ownership records:
+## Security
 
-```powershell
-./scripts/Remove-TenantObjects.ps1 -DeleteObjectsCreatedByThisEnvironment
-```
-
-PowerShell confirmation is required. Review the resolved and owned IDs first. Before deleting an exact-owned emergency group, the script removes that group ID from every Conditional Access policy exclusion so no stale deleted-object reference remains. The script never deletes supplied or reused users, groups, administrative units, API applications/service principals, mismatched IDs, unrelated workspaces, or untracked tenant objects. Do not replace the ownership-aware scripts with broad Graph or directory cleanup commands. Remove permanent role assignments and authentication methods according to your change process before or after deletion as required.
-
-## Troubleshooting
-
-- **Preprovision rejects an input:** correct the named environment variable; validation intentionally fails before Azure changes.
-- **Graph HTTP 403:** confirm the signed-in tenant, active Entra role, Graph delegated consent, and privilege elevation. Azure RBAC Owner does not grant Microsoft Graph privileges.
-- **Function returns 401/403:** confirm the playbook uses managed identity, Easy Auth is enabled, and its principal is authorized for the Function application.
-- **Sentinel automation does not run:** confirm Sentinel onboarding, `AuditLogs` ingestion, NRT rule health, Automation Contributor at playbook RG scope, and the automation rule's analytics-rule condition.
-- **Sentinel activity notification does not run:** confirm both `SigninLogs` and `AuditLogs` are in the Analytics tier, the playbook identity has Microsoft Sentinel Reader on the workspace, the automation rule triggers on incident creation, and Microsoft Sentinel has Automation Contributor on the playbook resource group.
-- **Teams message does not arrive:** for webhook mode, confirm the Workflow is enabled, has active owners, accepts unauthenticated calls, and has not rotated its URL. For API-connection mode, reauthorize the connection owner and verify the team/channel IDs and membership. Inspect the failed Logic App action without printing secrets.
-- **Sentinel playbook email fails:** open the supplied Office 365 Outlook API connection and reauthorize it as the dedicated automation account; the deployment rejects connections that are missing, in another region, or report an unauthenticated status.
-- **Sign-in alert deployment/query fails:** confirm the selected workspace exists, receives this tenant's `SigninLogs`, and the deployer can read the workspace and create scheduled-query rules/action groups in the environment resource group.
-- **Sign-in alert email does not arrive:** confirm the action group is enabled, the email address is correct, mail filtering permits Azure Monitor notifications, and the sign-in record landed inside the queried five-minute window.
-- **No Function deployment:** install Azure Functions Core Tools v4 and rerun `azd deploy`/`azd up`.
-- **TAP 403:** use the manual fallback in the TAP section; core remediation remains deployable.
-
-## Security limitations
-
-- Permanent Global Administrator is intentionally powerful. Use exactly two purpose-built cloud-only accounts and monitor them.
-- Conditional Access exclusion protects recoverability but removes controls represented by the excluded policies. Compensate with phishing-resistant credentials, secured devices/processes, and alerting.
-- Scheduled modes can leave a gap until their next run. Sentinel mode depends on prompt audit-log ingestion and healthy Sentinel automation.
-- This template cannot validate organizational approval, physical credential custody, or recovery drills.
-
-## Operational maintenance
-
-- Re-run the repository tests and `azd provision --preview` before deploying template changes.
-- Periodically review Bicep resource API versions, Azure Functions Flex Consumption conventions, Microsoft Graph PowerShell modules and permissions, and pinned GitHub Actions dependencies for supported replacements or security updates.
-- Re-test the complete Sentinel alert-to-Function path after Sentinel API, automation-rule, managed connector, or Easy Auth changes.
-- Re-test the sign-in alert and notification path after changing Entra diagnostic settings, the workspace, or the action group.
-- Exercise the emergency-access procedure regularly, including both users, at least two passkeys per user, monitoring, and documented credential custody.
-
-## References
-
-- [Manage emergency access accounts in Microsoft Entra ID](https://learn.microsoft.com/entra/identity/role-based-access-control/security-emergency-access)
-- [Temporary Access Pass](https://learn.microsoft.com/entra/identity/authentication/howto-authentication-temporary-access-pass)
-- [PowerShell developer reference for Azure Functions](https://learn.microsoft.com/azure/azure-functions/functions-reference-powershell)
-- [Flex Consumption plan](https://learn.microsoft.com/azure/azure-functions/flex-consumption-plan)
-- [Microsoft Sentinel NRT analytics rules](https://learn.microsoft.com/azure/sentinel/create-nrt-rules)
-- [Microsoft Sentinel automation rules](https://learn.microsoft.com/azure/sentinel/create-manage-use-automation-rules)
-- [Azure Monitor log search alerts](https://learn.microsoft.com/azure/azure-monitor/alerts/alerts-create-log-alert-rule)
-- [Azure Developer CLI template schema](https://learn.microsoft.com/azure/developer/azure-developer-cli/azd-schema)
-
-## License
+Permanent Global Administrator and Conditional Access exclusions are intentionally powerful. Use exactly two purpose-built cloud-only accounts, phishing-resistant authentication, independent monitoring, protected recovery devices, and regular drills. Review the [security model](docs/identity-and-authentication.md#security-boundaries) and report vulnerabilities through [SECURITY.md](SECURITY.md).
 
 Released into the public domain under the [Unlicense](LICENSE).

--- a/README.md
+++ b/README.md
@@ -1,14 +1,15 @@
 # Emergency access protection for Microsoft Entra
 
-Deploy and protect two Microsoft Entra emergency access accounts with a guided Azure Developer CLI experience.
+Deploy and protect Microsoft Entra emergency access accounts with a guided Azure Developer CLI experience.
 
 This template helps an administrator:
 
 1. Create or reuse two cloud-only emergency accounts.
-2. Place them in a dedicated group and assign Global Administrator when requested.
-3. Keep that group excluded from every Conditional Access policy.
+2. Optionally add a third, lower-privilege recovery account.
+3. Place them in a dedicated group and keep it excluded from every Conditional Access policy.
 4. Alert by email, Microsoft Sentinel, and Microsoft Teams when the accounts are used.
 5. Onboard phishing-resistant passkeys with Temporary Access Pass (TAP).
+6. Revoke onboarding sessions before assigning permanent administrator roles.
 
 > Emergency access accounts are a last-resort control. Follow [Microsoft's emergency access guidance](https://learn.microsoft.com/entra/identity/role-based-access-control/security-emergency-access), protect the credentials and devices, and test the complete recovery process regularly.
 
@@ -52,6 +53,7 @@ The first `azd up` walks through:
 
 - the remediation service, with a scheduled Azure Function recommended for most organizations;
 - creating, reusing, or externally managing the emergency identities;
+- an optional limited recovery account for Conditional Access and authentication-policy lockouts;
 - optional TAP and passkey onboarding;
 - Azure Monitor email, Sentinel and Teams, both notification paths, or later configuration;
 - normal Azure and Microsoft Graph browser consent.
@@ -60,7 +62,7 @@ The choices are saved in the azd environment, so rerunning `azd up` is non-destr
 
 ### Finish account onboarding
 
-If TAP onboarding was selected, each TAP is displayed exactly once. Before closing the terminal:
+If TAP onboarding was selected, each TAP is displayed exactly once. The deployment pauses while the custodians register passkeys, verifies that each account has a passkey, deletes the temporary passes, revokes the onboarding sessions, and only then assigns roles. Before closing the terminal:
 
 1. Securely give each TAP to its intended custodian.
 2. Sign in as each emergency account and register at least two passkeys.
@@ -75,7 +77,7 @@ Do not consider the deployment complete until both accounts and the notification
 ```mermaid
 flowchart LR
   Admin[Administrator] --> Wizard[azd guided setup]
-  Wizard --> Identities[Two emergency accounts and group]
+  Wizard --> Identities[Two GA accounts plus optional limited account]
   Wizard --> Remediator[Conditional Access remediator]
   Remediator --> Policies[All Conditional Access policies]
   Signins[SigninLogs and AuditLogs] --> Alerts[Azure Monitor or Sentinel]
@@ -120,6 +122,6 @@ Emergency tenant identities are intentionally retained. If this environment crea
 
 ## Security
 
-Permanent Global Administrator and Conditional Access exclusions are intentionally powerful. Use exactly two purpose-built cloud-only accounts, phishing-resistant authentication, independent monitoring, protected recovery devices, and regular drills. Review the [security model](docs/identity-and-authentication.md#security-boundaries) and report vulnerabilities through [SECURITY.md](SECURITY.md).
+Permanent administrator roles and Conditional Access exclusions are intentionally powerful. Maintain at least two purpose-built cloud-only Global Administrator accounts, phishing-resistant authentication, independent monitoring, protected recovery devices, and regular drills. The optional limited account supplements those two; it does not replace either one. Review the [security model](docs/identity-and-authentication.md#security-boundaries) and report vulnerabilities through [SECURITY.md](SECURITY.md).
 
 Released into the public domain under the [Unlicense](LICENSE).

--- a/docs/alerting-and-notifications.md
+++ b/docs/alerting-and-notifications.md
@@ -1,0 +1,78 @@
+# Alerting and notifications
+
+[Back to the quickstart](../README.md)
+
+Alerting is optional because Entra logs must already be routed to Log Analytics. The first-run wizard explains the prerequisites and can save alerting for later.
+
+## Notification architecture
+
+```mermaid
+flowchart LR
+  Signins[Entra SigninLogs] --> Monitor[Azure Monitor log alert]
+  Monitor --> ActionGroup[Action group]
+  ActionGroup --> Email[Critical email]
+
+  Signins --> Sentinel[Microsoft Sentinel]
+  Audits[Entra AuditLogs] --> Sentinel
+  Sentinel --> Rules[Sign-in, admin activity, and account-change rules]
+  Rules --> Incident[Sentinel incident]
+  Incident --> Playbook[Notification playbook]
+  Playbook --> Teams[Teams channel]
+  Playbook -. optional .-> Outlook[Outlook email]
+```
+
+## Azure Monitor email
+
+This path creates a severity-0 scheduled-query alert and an email action group. Every five minutes it searches for successful and failed sign-in records belonging to either emergency account. Failed attempts are included because they can reveal misuse even when authentication is blocked.
+
+Required inputs:
+
+- existing Log Analytics workspace receiving this tenant's `SigninLogs`;
+- one notification email address.
+
+The alert is stateless, so later activity can notify again rather than remaining hidden behind an unresolved alert.
+
+## Sentinel detections
+
+The optional Sentinel component creates high-severity detections for:
+
+- successful or failed emergency-account sign-ins;
+- directory or administrative activity performed by either account;
+- changes made to either emergency-account object.
+
+It requires an existing Sentinel-enabled workspace receiving `SigninLogs` and `AuditLogs` in the Analytics tier. The workspace can be in another subscription in the same tenant.
+
+The notification playbook identity receives Microsoft Sentinel Reader on the workspace. The Azure Security Insights service principal requires Microsoft Sentinel Automation Contributor on the playbook resource group so the automation rule can invoke it. The deployment assigns both roles and records their exact IDs for cleanup.
+
+## Teams delivery
+
+The recommended `admin-configured` experience is designed for a first-time administrator:
+
+1. Copy the target channel link in Microsoft Teams.
+2. Paste it into the wizard.
+3. Complete the single browser authorization URL printed after deployment.
+4. Return to the terminal so the deployment can verify the connection and enable the playbook.
+
+Use a dedicated automation account as the connection owner and assign durable operational owners. User OAuth is required only for the Teams connector authorization; the incident trigger itself uses managed identity.
+
+Advanced alternatives:
+
+- `workflow-webhook`: simple runtime delivery without a user token, but the callback URL is a bearer secret and the Teams Workflow still has an owner lifecycle;
+- `api-connection`: reuse an existing authorized Teams Logic Apps connection and supply explicit team/channel IDs;
+- proactive Teams bot: application identity at runtime, but requires hosting, tenant app approval, installation, and conversation-reference management.
+
+Direct Microsoft Graph application posting to ordinary Teams channels is not a supported shortcut; its application permission is limited to migration scenarios.
+
+## Optional playbook email
+
+Sentinel notifications can also use an existing authorized Office 365 Outlook Logic Apps connection. This is separate from the simpler Azure Monitor action-group email and has a delegated connection-owner lifecycle.
+
+For application-only branded email, consider Azure Communication Services as a separate organization-wide adapter rather than adding it to every deployment.
+
+## Delivery validation and health
+
+Set `AZD_TEST_SENTINEL_NOTIFICATION_DELIVERY=true` after the Teams connection is authorized to post one clearly labeled test message and fail when the real Logic App delivery action does not succeed.
+
+The Sentinel playbooks export `WorkflowRuntime` logs and metrics to existing workspaces. A central operations solution can alert on failed or disabled playbook runs without deploying a polling Function for each environment.
+
+Polling Microsoft Graph is intentionally not the default. Once `SigninLogs` and `AuditLogs` reach Sentinel, polling adds checkpoint, overlap, deduplication, retry, and `AuditLog.Read.All` responsibilities without improving critical detection. Use Event Hub or a polling adapter only for cross-tenant routing, third-party delivery, or custom correlation.

--- a/docs/conditional-access-remediation.md
+++ b/docs/conditional-access-remediation.md
@@ -1,0 +1,49 @@
+# Conditional Access remediation
+
+[Back to the quickstart](../README.md)
+
+The remediation workload keeps one designated emergency-access group in `conditions.users.excludeGroups` for every user-scoped Conditional Access policy.
+
+## Processing flow
+
+```mermaid
+flowchart TD
+  Start[Trigger] --> Read[Read authoritative policy state]
+  Read --> UserScope{User-scoped policy?}
+  UserScope -- No --> Skip[Skip safely]
+  UserScope -- Yes --> Present{Group already excluded?}
+  Present -- Yes --> Unchanged[Record unchanged]
+  Present -- No --> Patch[Append group and PATCH]
+  Patch --> Result[Return structured result]
+  Unchanged --> Result
+  Skip --> Result
+```
+
+The shared PowerShell core:
+
+- validates every supplied GUID before calling Microsoft Graph;
+- follows every Graph page in scheduled modes;
+- reads the current policy before changing it;
+- preserves and deduplicates every existing exclusion;
+- skips policies whose user target is `None`;
+- sends PATCH only when the emergency group is absent;
+- continues evaluating other policies after an individual failure;
+- returns evaluated, updated, unchanged, and failed counts with policy IDs.
+
+Any PATCH failure causes the invocation to fail after processing, so Azure Functions, Automation, or Logic Apps can surface the problem without leaving other policies unchecked.
+
+## Sentinel targeting
+
+Sentinel mode validates `CAPolicyId` and retrieves only that policy. The default NRT query detects successful Conditional Access policy additions or updates and ignores changes made by the remediation identity to avoid feedback loops.
+
+## Safe verification
+
+Use an approved report-only test policy:
+
+1. Create or update the policy without the emergency group exclusion.
+2. Trigger the selected workload or wait for the Sentinel rule.
+3. Confirm the group was appended and all prior exclusions remain.
+4. Run remediation again and confirm no PATCH is issued.
+5. Remove the test policy when the exercise is complete.
+
+Never test by weakening a production policy or using an emergency account for routine administration.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,87 @@
+# Configuration reference
+
+[Back to the quickstart](../README.md)
+
+The interactive wizard persists its choices in the current azd environment. Advanced administrators and the future graphical wizard can set the same values before `azd up`; when `AZD_DEPLOYMENT_MODE` is already set, the console wizard is skipped.
+
+## Core settings
+
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `AZD_DEPLOYMENT_MODE` | prompted | `function-scheduled`, `automation-scheduled`, `logicapp-scheduled`, or `sentinel-function` |
+| `AZURE_LOCATION` | `westus2` | Azure deployment region |
+| `AZD_EMERGENCY_DOMAIN` | none | Verified domain used when creating users |
+| `AZD_EMERGENCY_USER1_ID`, `AZD_EMERGENCY_USER2_ID` | none | Existing user object IDs |
+| `AZD_EMERGENCY_USER1_UPN`, `AZD_EMERGENCY_USER2_UPN` | none | Existing user principal names to resolve |
+| `AZD_EMERGENCY_GROUP_ID` | none | Existing emergency security-group object ID |
+| `AZD_ADMINISTRATIVE_UNIT_ID` | none | Existing administrative-unit object ID |
+| `AZD_MANAGE_EMERGENCY_IDENTITIES` | `true` | Set `false` to prevent user, group, role, AU, and TAP changes |
+| `AZD_USE_RESTRICTED_AU` | `true` | Create or reuse a restricted management administrative unit |
+| `AZD_ENABLE_TAP_POLICY` | `false` outside the wizard | Configure TAP and create interactive passes |
+| `AZD_RESOURCE_NAME_PREFIX` | environment-derived | Optional deterministic Azure resource prefix |
+
+## Scheduling
+
+| Variable | Default | Used by |
+| --- | --- | --- |
+| `AZD_SCHEDULE_CRON` | `0 0 */6 * * *` | Scheduled Function |
+| `AZD_SCHEDULE_INTERVAL` | `6` | Automation and scheduled Logic App |
+| `AZD_SCHEDULE_FREQUENCY` | `Hour` | Automation and scheduled Logic App |
+| `AZD_AUTOMATION_TIME_ZONE` | `Etc/UTC` | Azure Automation |
+| `AZD_AUTOMATION_START_TIME` | 15 minutes in the future | Azure Automation; refreshed before first creation when stale |
+
+## Azure Monitor sign-in alerting
+
+| Variable | Purpose |
+| --- | --- |
+| `AZD_ENABLE_SIGNIN_ALERTS` | Set `true` to deploy the alert and action group |
+| `AZD_SIGNIN_LOG_WORKSPACE_NAME` | Existing workspace receiving `SigninLogs` |
+| `AZD_SIGNIN_LOG_WORKSPACE_RESOURCE_GROUP` | Workspace resource group |
+| `AZD_SIGNIN_LOG_WORKSPACE_SUBSCRIPTION_ID` | Workspace subscription; defaults to the deployment or Sentinel subscription |
+| `AZD_SIGNIN_ALERT_EMAIL` | One plain email address |
+
+## Sentinel and Teams
+
+| Variable | Purpose |
+| --- | --- |
+| `AZD_ENABLE_SENTINEL_ACTIVITY_ALERTS` | Deploy emergency sign-in, activity, and account-change detections |
+| `AZD_SENTINEL_WORKSPACE_NAME` | Existing Sentinel workspace |
+| `AZD_SENTINEL_WORKSPACE_RESOURCE_GROUP` | Sentinel workspace resource group |
+| `AZD_SENTINEL_WORKSPACE_SUBSCRIPTION_ID` | Workspace subscription in the same tenant |
+| `AZD_SENTINEL_TEAMS_DELIVERY_MODE` | `admin-configured`, `workflow-webhook`, or `api-connection` |
+| `AZD_SENTINEL_TEAMS_CHANNEL_LINK` | Channel link copied from Teams for guided setup |
+| `AZD_SENTINEL_TEAMS_WEBHOOK_URL` | Secret callback URL for webhook mode |
+| `AZD_SENTINEL_TEAMS_CONNECTION_RESOURCE_ID` | Existing Teams API connection for API-connection mode |
+| `AZD_SENTINEL_TEAMS_TEAM_ID`, `AZD_SENTINEL_TEAMS_CHANNEL_ID` | Explicit destination IDs |
+| `AZD_TEST_SENTINEL_NOTIFICATION_DELIVERY` | Post and verify one labeled test notification |
+| `AZD_SENTINEL_OUTLOOK_CONNECTION_RESOURCE_ID` | Existing Outlook API connection for optional email |
+| `AZD_SENTINEL_NOTIFICATION_EMAIL` | Recipient used with the Outlook connection |
+
+Sentinel Function mode also uses hook-managed `AZD_FUNCTION_AUTH_CLIENT_ID` and `AZD_FUNCTION_AUTH_AUDIENCE`. Normally, do not set them manually.
+
+## Existing externally managed identities
+
+```powershell
+azd env set AZD_DEPLOYMENT_MODE function-scheduled
+azd env set AZD_MANAGE_EMERGENCY_IDENTITIES false
+azd env set AZD_EMERGENCY_GROUP_ID 22222222-2222-2222-2222-222222222222
+azd env set AZD_EMERGENCY_USER1_ID 11111111-1111-1111-1111-111111111111
+azd env set AZD_EMERGENCY_USER2_ID 44444444-4444-4444-4444-444444444444
+azd up
+```
+
+The user IDs are required when alerting is enabled. The group ID is always required because the remediation workload uses it.
+
+## Preview and noninteractive deployment
+
+The first `azd provision --preview` does not execute project hooks. When object IDs have not yet been resolved, run:
+
+```powershell
+azd hooks run preprovision
+azd provision --preview
+azd up
+```
+
+For CI or another controller, set `AZD_NON_INTERACTIVE=true`, set `AZD_DEPLOYMENT_MODE` and every required value, authenticate Azure using workload identity federation, and establish one compatible standard `Connect-MgGraph` delegated context before hooks run. TAP values are never emitted noninteractively.
+
+The graphical wizard should write these same environment values and then invoke the existing azd lifecycle. It should not create a separate deployment contract.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -13,11 +13,14 @@ The interactive wizard persists its choices in the current azd environment. Adva
 | `AZD_EMERGENCY_DOMAIN` | none | Verified domain used when creating users |
 | `AZD_EMERGENCY_USER1_ID`, `AZD_EMERGENCY_USER2_ID` | none | Existing user object IDs |
 | `AZD_EMERGENCY_USER1_UPN`, `AZD_EMERGENCY_USER2_UPN` | none | Existing user principal names to resolve |
+| `AZD_ENABLE_LIMITED_EMERGENCY_ACCOUNT` | `false` | Add a third account with Conditional Access Administrator and Authentication Policy Administrator |
+| `AZD_EMERGENCY_USER3_ID`, `AZD_EMERGENCY_USER3_UPN` | none | Optional limited emergency account reference; otherwise it is created from `AZD_EMERGENCY_DOMAIN` |
 | `AZD_EMERGENCY_GROUP_ID` | none | Existing emergency security-group object ID |
 | `AZD_ADMINISTRATIVE_UNIT_ID` | none | Existing administrative-unit object ID |
 | `AZD_MANAGE_EMERGENCY_IDENTITIES` | `true` | Set `false` to prevent user, group, role, AU, and TAP changes |
 | `AZD_USE_RESTRICTED_AU` | `true` | Create or reuse a restricted management administrative unit |
 | `AZD_ENABLE_TAP_POLICY` | `false` outside the wizard | Configure TAP and create interactive passes |
+| `AZD_AUTHENTICATION_READY` | `false` | Explicit noninteractive confirmation when TAP is skipped for existing managed accounts |
 | `AZD_RESOURCE_NAME_PREFIX` | environment-derived | Optional deterministic Azure resource prefix |
 
 ## Scheduling

--- a/docs/deployment-modes.md
+++ b/docs/deployment-modes.md
@@ -1,0 +1,48 @@
+# Deployment modes
+
+[Back to the quickstart](../README.md)
+
+The wizard recommends `function-scheduled` because it is serverless, uses managed identity, and checks every Conditional Access policy on a predictable schedule. Select another mode when it better matches the operating model already used by your organization.
+
+| Mode | Trigger | Behavior | Choose it when |
+| --- | --- | --- | --- |
+| `function-scheduled` | Azure Functions timer | Checks every policy every six hours by default | You want the recommended general-purpose deployment |
+| `automation-scheduled` | Azure Automation schedule | Checks every policy every six hours by default | Your operations team manages PowerShell runbooks |
+| `logicapp-scheduled` | Consumption Logic App recurrence | Checks every policy every six hours by default | Your operations team prefers low-code workflows |
+| `sentinel-function` | Sentinel NRT analytics and automation rules | Repairs only the policy identified by the alert | Entra `AuditLogs` already flow to Microsoft Sentinel |
+
+An azd environment is locked to its successfully provisioned mode. Run `azd down` before changing modes, or create a separate azd environment. This prevents an old remediator from remaining active after an incremental deployment.
+
+## Scheduled modes
+
+```mermaid
+flowchart LR
+  Schedule[Timer or schedule] --> Workload[Managed-identity workload]
+  Workload --> Graph[Microsoft Graph]
+  Graph --> Policies[All Conditional Access policies]
+  Policies --> Exclusion[Ensure emergency group exclusion]
+```
+
+Scheduled modes provide periodic self-healing and do not depend on audit-log ingestion. The default six-hour interval can be changed through the [configuration reference](configuration.md).
+
+## Sentinel-targeted mode
+
+```mermaid
+flowchart LR
+  Audit[Entra AuditLogs] --> NRT[Sentinel NRT rule]
+  NRT --> Alert[Alert containing CAPolicyId]
+  Alert --> Automation[Automation rule]
+  Automation --> Playbook[Managed-identity playbook]
+  Playbook --> Function[Entra-protected Function]
+  Function --> Policy[Changed policy only]
+```
+
+The targeted mode reacts quickly and avoids a full policy sweep. It requires an existing Sentinel-enabled workspace receiving Entra `AuditLogs`. The workspace can be in another subscription in the same tenant.
+
+The playbook invokes the Function with managed identity. App Service Authentication validates the application audience and permits only the playbook principal. No client secret or Function key is created.
+
+## Azure resources
+
+Depending on the selected mode, the deployment creates the workload, managed identities, least-privilege role assignments, operational logging, and supporting storage. Function storage uses identity-based access with shared-key access disabled.
+
+For exact resource definitions, review [`infra/main.bicep`](../infra/main.bicep) and the [`infra/modes`](../infra/modes) folder.

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,0 +1,39 @@
+# Development and publishing
+
+[Back to the quickstart](../README.md)
+
+## Validate a change
+
+Run the same core checks used by GitHub Actions:
+
+```powershell
+$result = Invoke-Pester ./tests -PassThru
+if ($result.FailedCount -gt 0) { throw 'Pester validation failed.' }
+
+az bicep build --file ./infra/main.bicep
+git diff --exit-code -- ./infra/main.json
+```
+
+The repository's [`.gitattributes`](../.gitattributes) keeps Bicep and embedded PowerShell inputs on LF endings so Windows and Linux produce the same ARM template hash.
+
+Also parse all PowerShell files and JSON metadata before publishing. The `Validate template` workflow performs these checks on pull requests and `main`.
+
+## Generated ARM template
+
+[`infra/main.bicep`](../infra/main.bicep) is the source of truth and [`infra/main.json`](../infra/main.json) is its checked-in generated form. Always regenerate and review both together after changing Bicep. Do not hand-edit the generated JSON.
+
+## Catalog metadata
+
+Public catalog metadata is stored in [`.azd/catalog.json`](../.azd/catalog.json). Keep its quickstart synchronized with the root README and test the real public-template initialization path before release.
+
+Changes to catalog inputs on `main` trigger [the publishing workflow](../.github/workflows/publish-azd-catalog.yml). It sends an `azd-catalog-updated` repository dispatch to `nathanmcnulty/azd-website`.
+
+`AZD_CATALOG_TOKEN` should be a fine-grained repository secret able to send repository dispatches to `nathanmcnulty/azd-website` with repository Contents read/write access. When the secret is absent, the workflow reports that publishing was skipped without failing template validation.
+
+## Pull-request expectations
+
+- Keep GitHub Actions pinned by full commit SHA.
+- Preserve generated ARM parity.
+- Add focused tests for lifecycle, ownership, authentication, and administrator-facing contract changes.
+- Never introduce device-code authentication or stored credentials.
+- Do not weaken exact-ownership teardown guards to make cleanup more convenient.

--- a/docs/identity-and-authentication.md
+++ b/docs/identity-and-authentication.md
@@ -7,8 +7,10 @@
 The first-run wizard offers three paths:
 
 1. **Create two accounts.** The template creates two cloud-only users, a security group, permanent Global Administrator assignments, and a restricted management administrative unit by default.
-2. **Use existing accounts.** The template resolves the supplied UPNs or object IDs, ensures group membership and Global Administrator, and can create the group when it is missing.
+2. **Use existing accounts.** The template resolves the supplied UPNs or object IDs, ensures group membership and permanent Global Administrator assignments, and can create the group when it is missing.
 3. **Use externally managed accounts.** The template requires exact object IDs and does not modify users, group membership, directory roles, administrative units, or TAP configuration.
+
+For either managed path, you can add an optional third account. It receives permanent **Conditional Access Administrator** and **Authentication Policy Administrator** roles, joins the same protected group and administrative unit, and is included in every alert query. It can recover common Conditional Access and authentication-method policy lockouts with substantially less authority than Global Administrator. It cannot perform general tenant recovery or manage individual users' authentication methods, so it supplements rather than replaces either Global Administrator emergency account.
 
 The deployment records exact ownership IDs for objects it creates. It refuses to replace an owned privileged object until the original is explicitly cleaned up.
 
@@ -45,19 +47,39 @@ The generated password cannot be recovered. Use TAP onboarding or your approved 
 
 ## TAP and passkeys
 
-The wizard recommends TAP when the template manages the identities. When selected, it:
+The wizard requires TAP when it creates identities and recommends it for existing identities. When selected, it:
 
 1. Merges the emergency group into the existing TAP policy targets without replacing other targets.
 2. Creates one reusable two-hour TAP per account.
 3. Displays each TAP once in the interactive terminal.
+4. Pauses while the custodians register passkeys and verifies at least one passkey per account through Microsoft Graph.
+5. Deletes the temporary passes and revokes all onboarding sessions before assigning permanent administrator roles.
 
-Immediately register at least two passkeys per account and test both. TAP values are not generated in noninteractive runs because they cannot be delivered safely.
+Register at least one passkey per account to pass the deployment gate. Two passkeys per account, stored with separate custodians or in separate secure locations, are strongly recommended. TAP values are not generated in noninteractive runs because they cannot be delivered safely.
 
-If TAP configuration receives HTTP 403, core deployment remains valid. Complete TAP and passkey registration manually after granting the necessary authentication-method permissions.
+If TAP is skipped for existing identities, the interactive deployment requires the administrator to confirm that every account already has tested phishing-resistant authentication. A noninteractive deployment must set `AZD_AUTHENTICATION_READY=true` explicitly. The account IDs are fingerprinted after onboarding so normal reruns do not revoke sessions again; changing the managed account set repeats the hardening gate.
+
+The session-revocation operation invalidates Entra refresh tokens. Application session cookies can persist until the application reevaluates them, so close every private onboarding session after passkey registration.
+
+## Provisioning order
+
+```mermaid
+flowchart LR
+  A[Resolve accounts] --> B[Group and optional restricted AU]
+  B --> C[Deploy CA remediator]
+  C --> D[Immediate CA exclusion reconciliation]
+  D --> E[Verify phishing-resistant authentication]
+  E --> F[Revoke onboarding sessions]
+  F --> G[Assign permanent roles]
+  G --> H[Enable recurring protection and alerts]
+```
+
+The immediate reconciliation fails closed: administrator roles are not assigned if the emergency group cannot first be excluded from a user-scoped Conditional Access policy. The scheduled workload then maintains that invariant.
 
 ## Security boundaries
 
 - A restricted management administrative unit reduces routine administrative exposure, but Global Administrators can still manage restricted objects.
+- The limited account's role combination can change tenant-wide Conditional Access and authentication-method policy. Treat it as emergency access even though it is less privileged than Global Administrator.
 - Conditional Access exclusion preserves recoverability but bypasses the protections represented by those policies.
 - Keep accounts cloud-only and separate their credentials, passkeys, devices, and custodians from normal administration.
 - Treat every sign-in attempt, successful or failed, as security-relevant.

--- a/docs/identity-and-authentication.md
+++ b/docs/identity-and-authentication.md
@@ -1,0 +1,64 @@
+# Identity and authentication
+
+[Back to the quickstart](../README.md)
+
+## Identity choices
+
+The first-run wizard offers three paths:
+
+1. **Create two accounts.** The template creates two cloud-only users, a security group, permanent Global Administrator assignments, and a restricted management administrative unit by default.
+2. **Use existing accounts.** The template resolves the supplied UPNs or object IDs, ensures group membership and Global Administrator, and can create the group when it is missing.
+3. **Use externally managed accounts.** The template requires exact object IDs and does not modify users, group membership, directory roles, administrative units, or TAP configuration.
+
+The deployment records exact ownership IDs for objects it creates. It refuses to replace an owned privileged object until the original is explicitly cleaned up.
+
+## Required administrator access
+
+The deploying administrator normally needs:
+
+- Azure subscription Contributor plus User Access Administrator, or Owner;
+- Global Administrator or Privileged Role Administrator for the emergency-account role assignments;
+- permission to grant the delegated Microsoft Graph scopes requested for the selected capabilities;
+- access to the existing Log Analytics or Sentinel workspace when alerting is selected.
+
+Activate eligible roles before `azd up`. Azure RBAC does not grant Microsoft Entra or Microsoft Graph privileges.
+
+## Microsoft Graph authentication
+
+Install the authentication module once:
+
+```powershell
+Install-Module Microsoft.Graph.Authentication -Scope CurrentUser
+```
+
+The first tenant phase calls standard `Connect-MgGraph` once with the complete scope set required by the wizard choices. Windows Account Manager, the current token cache, or a normal browser performs authentication. Later phases use `Connect-MgGraph -NoWelcome` and the same cached context.
+
+If consent is missing, the deployment stops with the missing scopes instead of launching several new prompts. Device-code authentication, client secrets, and Azure CLI Graph tokens are not used.
+
+Runtime workloads use managed identity with `Policy.Read.All`, `Policy.ReadWrite.ConditionalAccess`, and `Application.Read.All`. `Application.Read.All` is included because Conditional Access PATCH currently requires that application permission in addition to the policy permissions.
+
+## Password handling
+
+Microsoft Graph requires an initial password when a user is created. The template generates a cryptographically random value and immediately discards it. It is never printed, returned, stored in azd, written to disk, or placed in Key Vault.
+
+The generated password cannot be recovered. Use TAP onboarding or your approved authentication-method process.
+
+## TAP and passkeys
+
+The wizard recommends TAP when the template manages the identities. When selected, it:
+
+1. Merges the emergency group into the existing TAP policy targets without replacing other targets.
+2. Creates one reusable two-hour TAP per account.
+3. Displays each TAP once in the interactive terminal.
+
+Immediately register at least two passkeys per account and test both. TAP values are not generated in noninteractive runs because they cannot be delivered safely.
+
+If TAP configuration receives HTTP 403, core deployment remains valid. Complete TAP and passkey registration manually after granting the necessary authentication-method permissions.
+
+## Security boundaries
+
+- A restricted management administrative unit reduces routine administrative exposure, but Global Administrators can still manage restricted objects.
+- Conditional Access exclusion preserves recoverability but bypasses the protections represented by those policies.
+- Keep accounts cloud-only and separate their credentials, passkeys, devices, and custodians from normal administration.
+- Treat every sign-in attempt, successful or failed, as security-relevant.
+- Exercise the complete emergency procedure regularly; successful deployment alone does not prove recoverability.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -1,0 +1,65 @@
+# Operations
+
+[Back to the quickstart](../README.md)
+
+## Verify a deployment
+
+1. Confirm both emergency accounts can sign in with their registered passkeys.
+2. Confirm the emergency group is excluded from every applicable Conditional Access policy.
+3. Use an approved report-only test policy to prove remediation and idempotency.
+4. Confirm Azure Monitor email for both a successful and failed test sign-in when enabled.
+5. Confirm the Sentinel incident, Logic App run, Teams message, and optional email when enabled.
+6. Perform an approved harmless directory change with a test emergency account and confirm the activity detection.
+7. Record the drill results, custodians, recovery devices, and any remediation work.
+
+Repository validation:
+
+```powershell
+Invoke-Pester ./tests
+az bicep build --file ./infra/main.bicep
+git diff --exit-code -- ./infra/main.json
+```
+
+## Common problems
+
+- **A prerequisite command is missing:** install the tool named by the error and rerun `azd up`; the deployment is idempotent.
+- **Microsoft Graph returns HTTP 403:** confirm the tenant, activated Entra role, and delegated consent. Azure Owner does not grant Graph privileges.
+- **The cached Graph context lacks scopes:** run the one standard `Connect-MgGraph` initialization described by the error. Do not use device-code authentication.
+- **Function deployment is skipped:** install Azure Functions Core Tools v4 and run `azd deploy` or `azd up` again.
+- **Function returns 401 or 403:** confirm Easy Auth, its application audience, and the allowed playbook principal.
+- **Sentinel automation does not run:** confirm `AuditLogs` ingestion, NRT rule health, Automation Contributor on the playbook resource group, and the automation-rule condition.
+- **No Teams message arrives:** reauthorize the connection owner, verify team/channel membership, and inspect the failed Logic App action without printing secrets.
+- **No sign-in email arrives:** confirm the email action group and that the `SigninLogs` record reached the selected workspace.
+- **TAP returns HTTP 403:** finish TAP and passkey onboarding manually; the core remediation deployment remains valid.
+
+## Routine maintenance
+
+- Exercise both accounts, both sets of passkeys, and all notification paths on an approved schedule.
+- Retest Teams after connection-owner, token, Conditional Access, or channel changes.
+- Retest Sentinel after connector, analytics-rule, automation-rule, or Easy Auth changes.
+- Review emergency-account sign-in and audit incidents even when a drill was expected.
+- Review Azure API versions, Functions runtime support, Graph permissions, and pinned GitHub Actions dependencies during template updates.
+
+## Remove Azure resources
+
+```powershell
+azd down --purge --force
+```
+
+The predown hook deletes only exact IDs recorded as owned by this environment, including external Sentinel rules and role assignments. If ownership cannot be proven, teardown stops instead of broadening deletion. Existing workspaces and supplied API connections are never deleted.
+
+## Remove tenant identities
+
+Normal Azure cleanup deliberately retains the emergency accounts and group. Only after explicit approval, delete exact-owned tenant objects with:
+
+```powershell
+./scripts/Remove-TenantObjects.ps1 -DeleteObjectsCreatedByThisEnvironment
+```
+
+The script requires confirmation and deletes only objects whose current IDs match the recorded ownership IDs. Before deleting an owned emergency group, it removes that exact ID from Conditional Access exclusions. Supplied or mismatched objects are retained.
+
+## Central monitoring and audit retention
+
+For organization-wide coverage, use Azure Policy to route platform diagnostic settings and Azure Activity Logs into a central Log Analytics or Sentinel workspace. Configure Entra diagnostic settings once per tenant for `SigninLogs` and `AuditLogs`.
+
+The playbook diagnostic settings in this template provide run data but do not create a separate health-alert stack. A central alert can monitor failed or disabled Logic App runs across deployments. Use a polling Function or the Microsoft 365 Management Activity API only when delayed aggregation, export, cross-tenant routing, or a destination outside Azure Monitor/Sentinel requires it.

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -66,6 +66,7 @@ param sentinelAccountChangeRuleId string = ''
 param sentinelNotificationAutomationRuleId string = ''
 param emergencyUser1ObjectId string = ''
 param emergencyUser2ObjectId string = ''
+param emergencyUser3ObjectId string = ''
 var effectiveScheduleStartTime = empty(scheduleStartTime)
   ? generatedScheduleStartTime
   : scheduleStartTime
@@ -146,6 +147,7 @@ module signInAlerting 'modules/signin-alerting.bicep' = if (enableSignInAlerts =
     workspaceResourceId: signInLogWorkspace!.id
     emergencyUser1ObjectId: emergencyUser1ObjectId
     emergencyUser2ObjectId: emergencyUser2ObjectId
+    emergencyUser3ObjectId: emergencyUser3ObjectId
     notificationEmail: signInAlertEmail
   }
 }
@@ -162,6 +164,7 @@ module sentinelActivityAlerting 'modules/sentinel-activity-alerting.bicep' = if 
     diagnosticsWorkspaceResourceId: sentinelWorkspace!.id
     emergencyUser1ObjectId: emergencyUser1ObjectId
     emergencyUser2ObjectId: emergencyUser2ObjectId
+    emergencyUser3ObjectId: emergencyUser3ObjectId
     sentinelServicePrincipalId: sentinelServicePrincipalId
     assignAutomationContributor: deploymentMode != 'sentinel-function'
     teamsWebhookUrl: sentinelTeamsWebhookUrl

--- a/infra/main.json
+++ b/infra/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.42.1.51946",
-      "templateHash": "12490156290231570481"
+      "templateHash": "8790044751768549592"
     }
   },
   "parameters": {
@@ -186,6 +186,10 @@
       "defaultValue": ""
     },
     "emergencyUser2ObjectId": {
+      "type": "string",
+      "defaultValue": ""
+    },
+    "emergencyUser3ObjectId": {
       "type": "string",
       "defaultValue": ""
     }
@@ -3079,6 +3083,9 @@
           "emergencyUser2ObjectId": {
             "value": "[parameters('emergencyUser2ObjectId')]"
           },
+          "emergencyUser3ObjectId": {
+            "value": "[parameters('emergencyUser3ObjectId')]"
+          },
           "notificationEmail": {
             "value": "[parameters('signInAlertEmail')]"
           }
@@ -3090,7 +3097,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.42.1.51946",
-              "templateHash": "9422782683407757123"
+              "templateHash": "13535900583588971830"
             }
           },
           "parameters": {
@@ -3115,12 +3122,16 @@
               "type": "string",
               "minLength": 1
             },
+            "emergencyUser3ObjectId": {
+              "type": "string",
+              "defaultValue": ""
+            },
             "notificationEmail": {
               "type": "string"
             }
           },
           "variables": {
-            "signInQuery": "[join(createArray('SigninLogs', '| where ingestion_time() >= ago(5m)', format('| where UserId in~ (\"{0}\", \"{1}\")', parameters('emergencyUser1ObjectId'), parameters('emergencyUser2ObjectId')), '| project TimeGenerated, UserPrincipalName, UserId, IPAddress, AppDisplayName, ResourceDisplayName, ResultType, ResultDescription, CorrelationId'), '\n')]"
+            "signInQuery": "[join(createArray('SigninLogs', '| where ingestion_time() >= ago(5m)', format('| where UserId in~ (\"{0}\", \"{1}\", \"{2}\")', parameters('emergencyUser1ObjectId'), parameters('emergencyUser2ObjectId'), parameters('emergencyUser3ObjectId')), '| project TimeGenerated, UserPrincipalName, UserId, IPAddress, AppDisplayName, ResourceDisplayName, ResultType, ResultDescription, CorrelationId'), '\n')]"
           },
           "resources": [
             {
@@ -3236,6 +3247,9 @@
           "emergencyUser2ObjectId": {
             "value": "[parameters('emergencyUser2ObjectId')]"
           },
+          "emergencyUser3ObjectId": {
+            "value": "[parameters('emergencyUser3ObjectId')]"
+          },
           "sentinelServicePrincipalId": {
             "value": "[parameters('sentinelServicePrincipalId')]"
           },
@@ -3283,7 +3297,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.42.1.51946",
-              "templateHash": "15671240657378624383"
+              "templateHash": "1594195961887270460"
             }
           },
           "parameters": {
@@ -3314,6 +3328,10 @@
             },
             "emergencyUser2ObjectId": {
               "type": "string"
+            },
+            "emergencyUser3ObjectId": {
+              "type": "string",
+              "defaultValue": ""
             },
             "sentinelServicePrincipalId": {
               "type": "string"
@@ -3597,6 +3615,9 @@
                   "emergencyUser2ObjectId": {
                     "value": "[parameters('emergencyUser2ObjectId')]"
                   },
+                  "emergencyUser3ObjectId": {
+                    "value": "[parameters('emergencyUser3ObjectId')]"
+                  },
                   "playbookId": {
                     "value": "[resourceId('Microsoft.Logic/workflows', variables('playbookName'))]"
                   },
@@ -3626,7 +3647,7 @@
                     "_generator": {
                       "name": "bicep",
                       "version": "0.42.1.51946",
-                      "templateHash": "5892261026648404064"
+                      "templateHash": "7422110210475170214"
                     }
                   },
                   "parameters": {
@@ -3641,6 +3662,10 @@
                     },
                     "emergencyUser2ObjectId": {
                       "type": "string"
+                    },
+                    "emergencyUser3ObjectId": {
+                      "type": "string",
+                      "defaultValue": ""
                     },
                     "playbookId": {
                       "type": "string"
@@ -3665,9 +3690,9 @@
                     }
                   },
                   "variables": {
-                    "signInQuery": "[join(createArray('SigninLogs', format('| where UserId in~ (\"{0}\", \"{1}\")', parameters('emergencyUser1ObjectId'), parameters('emergencyUser2ObjectId')), '| project TimeGenerated, UserPrincipalName, UserId, IPAddress, AppDisplayName, ResourceDisplayName, ResultType, ResultDescription, CorrelationId'), '\n')]",
-                    "adminActivityQuery": "[join(createArray('AuditLogs', '| extend ActorUserId = tostring(InitiatedBy.user.id), ActorUserPrincipalName = tostring(InitiatedBy.user.userPrincipalName)', format('| where ActorUserId in~ (\"{0}\", \"{1}\")', parameters('emergencyUser1ObjectId'), parameters('emergencyUser2ObjectId')), '| project TimeGenerated, ActorUserPrincipalName, ActorUserId, OperationName, Category, Result, ResultReason, LoggedByService, CorrelationId'), '\n')]",
-                    "accountChangeQuery": "[join(createArray('AuditLogs', '| mv-expand TargetResource = TargetResources', '| extend TargetUserId = tostring(TargetResource.id), TargetUserPrincipalName = tostring(TargetResource.userPrincipalName)', format('| where TargetUserId in~ (\"{0}\", \"{1}\")', parameters('emergencyUser1ObjectId'), parameters('emergencyUser2ObjectId')), '| extend ActorUserPrincipalName = coalesce(tostring(InitiatedBy.user.userPrincipalName), tostring(InitiatedBy.app.displayName), Identity)', '| project TimeGenerated, TargetUserPrincipalName, TargetUserId, ActorUserPrincipalName, OperationName, Category, Result, ResultReason, LoggedByService, CorrelationId'), '\n')]"
+                    "signInQuery": "[join(createArray('SigninLogs', format('| where UserId in~ (\"{0}\", \"{1}\", \"{2}\")', parameters('emergencyUser1ObjectId'), parameters('emergencyUser2ObjectId'), parameters('emergencyUser3ObjectId')), '| project TimeGenerated, UserPrincipalName, UserId, IPAddress, AppDisplayName, ResourceDisplayName, ResultType, ResultDescription, CorrelationId'), '\n')]",
+                    "adminActivityQuery": "[join(createArray('AuditLogs', '| extend ActorUserId = tostring(InitiatedBy.user.id), ActorUserPrincipalName = tostring(InitiatedBy.user.userPrincipalName)', format('| where ActorUserId in~ (\"{0}\", \"{1}\", \"{2}\")', parameters('emergencyUser1ObjectId'), parameters('emergencyUser2ObjectId'), parameters('emergencyUser3ObjectId')), '| project TimeGenerated, ActorUserPrincipalName, ActorUserId, OperationName, Category, Result, ResultReason, LoggedByService, CorrelationId'), '\n')]",
+                    "accountChangeQuery": "[join(createArray('AuditLogs', '| mv-expand TargetResource = TargetResources', '| extend TargetUserId = tostring(TargetResource.id), TargetUserPrincipalName = tostring(TargetResource.userPrincipalName)', format('| where TargetUserId in~ (\"{0}\", \"{1}\", \"{2}\")', parameters('emergencyUser1ObjectId'), parameters('emergencyUser2ObjectId'), parameters('emergencyUser3ObjectId')), '| extend ActorUserPrincipalName = coalesce(tostring(InitiatedBy.user.userPrincipalName), tostring(InitiatedBy.app.displayName), Identity)', '| project TimeGenerated, TargetUserPrincipalName, TargetUserId, ActorUserPrincipalName, OperationName, Category, Result, ResultReason, LoggedByService, CorrelationId'), '\n')]"
                   },
                   "resources": [
                     {

--- a/infra/main.parameters.json
+++ b/infra/main.parameters.json
@@ -38,6 +38,7 @@
     "sentinelAccountChangeRuleId": { "value": "${AZD_SENTINEL_ACCOUNT_CHANGE_RULE_ID=}" },
     "sentinelNotificationAutomationRuleId": { "value": "${AZD_SENTINEL_NOTIFICATION_AUTOMATION_RULE_ID=}" },
     "emergencyUser1ObjectId": { "value": "${AZD_EMERGENCY_USER1_ID=}" },
-    "emergencyUser2ObjectId": { "value": "${AZD_EMERGENCY_USER2_ID=}" }
+    "emergencyUser2ObjectId": { "value": "${AZD_EMERGENCY_USER2_ID=}" },
+    "emergencyUser3ObjectId": { "value": "${AZD_EMERGENCY_USER3_ID=}" }
   }
 }

--- a/infra/modules/sentinel-activity-alerting.bicep
+++ b/infra/modules/sentinel-activity-alerting.bicep
@@ -7,6 +7,7 @@ param workspaceResourceGroup string
 param diagnosticsWorkspaceResourceId string
 param emergencyUser1ObjectId string
 param emergencyUser2ObjectId string
+param emergencyUser3ObjectId string = ''
 param sentinelServicePrincipalId string
 param assignAutomationContributor bool
 @secure()
@@ -322,6 +323,7 @@ module activityRules 'sentinel-activity-rules.bicep' = {
     namePrefix: namePrefix
     emergencyUser1ObjectId: emergencyUser1ObjectId
     emergencyUser2ObjectId: emergencyUser2ObjectId
+    emergencyUser3ObjectId: emergencyUser3ObjectId
     playbookId: playbook.id
     playbookPrincipalId: playbookIdentity.outputs.principalId
     tenantId: tenant().tenantId

--- a/infra/modules/sentinel-activity-rules.bicep
+++ b/infra/modules/sentinel-activity-rules.bicep
@@ -2,6 +2,7 @@ param workspaceName string
 param namePrefix string
 param emergencyUser1ObjectId string
 param emergencyUser2ObjectId string
+param emergencyUser3ObjectId string = ''
 param playbookId string
 param playbookPrincipalId string
 param tenantId string
@@ -17,7 +18,7 @@ resource workspace 'Microsoft.OperationalInsights/workspaces@2023-09-01' existin
 var signInQuery = join(
   [
     'SigninLogs'
-    '| where UserId in~ ("${emergencyUser1ObjectId}", "${emergencyUser2ObjectId}")'
+    '| where UserId in~ ("${emergencyUser1ObjectId}", "${emergencyUser2ObjectId}", "${emergencyUser3ObjectId}")'
     '| project TimeGenerated, UserPrincipalName, UserId, IPAddress, AppDisplayName, ResourceDisplayName, ResultType, ResultDescription, CorrelationId'
   ],
   '\n'
@@ -27,7 +28,7 @@ var adminActivityQuery = join(
   [
     'AuditLogs'
     '| extend ActorUserId = tostring(InitiatedBy.user.id), ActorUserPrincipalName = tostring(InitiatedBy.user.userPrincipalName)'
-    '| where ActorUserId in~ ("${emergencyUser1ObjectId}", "${emergencyUser2ObjectId}")'
+    '| where ActorUserId in~ ("${emergencyUser1ObjectId}", "${emergencyUser2ObjectId}", "${emergencyUser3ObjectId}")'
     '| project TimeGenerated, ActorUserPrincipalName, ActorUserId, OperationName, Category, Result, ResultReason, LoggedByService, CorrelationId'
   ],
   '\n'
@@ -38,7 +39,7 @@ var accountChangeQuery = join(
     'AuditLogs'
     '| mv-expand TargetResource = TargetResources'
     '| extend TargetUserId = tostring(TargetResource.id), TargetUserPrincipalName = tostring(TargetResource.userPrincipalName)'
-    '| where TargetUserId in~ ("${emergencyUser1ObjectId}", "${emergencyUser2ObjectId}")'
+    '| where TargetUserId in~ ("${emergencyUser1ObjectId}", "${emergencyUser2ObjectId}", "${emergencyUser3ObjectId}")'
     '| extend ActorUserPrincipalName = coalesce(tostring(InitiatedBy.user.userPrincipalName), tostring(InitiatedBy.app.displayName), Identity)'
     '| project TimeGenerated, TargetUserPrincipalName, TargetUserId, ActorUserPrincipalName, OperationName, Category, Result, ResultReason, LoggedByService, CorrelationId'
   ],

--- a/infra/modules/signin-alerting.bicep
+++ b/infra/modules/signin-alerting.bicep
@@ -6,12 +6,13 @@ param workspaceResourceId string
 param emergencyUser1ObjectId string
 @minLength(1)
 param emergencyUser2ObjectId string
+param emergencyUser3ObjectId string = ''
 param notificationEmail string
 
 var signInQuery = join([
   'SigninLogs'
   '| where ingestion_time() >= ago(5m)'
-  '| where UserId in~ ("${emergencyUser1ObjectId}", "${emergencyUser2ObjectId}")'
+  '| where UserId in~ ("${emergencyUser1ObjectId}", "${emergencyUser2ObjectId}", "${emergencyUser3ObjectId}")'
   '| project TimeGenerated, UserPrincipalName, UserId, IPAddress, AppDisplayName, ResourceDisplayName, ResultType, ResultDescription, CorrelationId'
 ], '\n')
 

--- a/scripts/Bootstrap-Tenant.ps1
+++ b/scripts/Bootstrap-Tenant.ps1
@@ -7,6 +7,7 @@ param(
 $ErrorActionPreference = 'Stop'
 $graphRoot = 'https://graph.microsoft.com'
 Import-Module "$PSScriptRoot\Tenant.Guards.psm1" -Force
+Import-Module "$PSScriptRoot\..\src\functions\shared\EmergencyAccess.Remediation.psm1" -Force
 Assert-AzdTenantContext
 
 function Test-Interactive {
@@ -23,7 +24,8 @@ function Connect-ProjectGraph {
             'User.ReadWrite.All',
             'Group.ReadWrite.All',
             'AdministrativeUnit.ReadWrite.All',
-            'RoleManagement.ReadWrite.Directory'
+            'RoleManagement.ReadWrite.Directory',
+            'User.RevokeSessions.All'
         ) | ForEach-Object { $scopes.Add($_) }
     }
     @(
@@ -135,7 +137,7 @@ function New-DiscardedPassword {
 function Resolve-EmergencyUser {
     param(
         [Parameter(Mandatory)]
-        [ValidateSet(1, 2)]
+        [ValidateSet(1, 2, 3)]
         [int] $Number
     )
 
@@ -258,18 +260,34 @@ function Resolve-AdministrativeUnit {
     return $unit
 }
 
-function Ensure-GlobalAdministrator {
-    param([Parameter(Mandatory)][string] $UserId)
+function Ensure-DirectoryRoleAssignment {
+    param(
+        [Parameter(Mandatory)][string] $UserId,
+        [Parameter(Mandatory)][string] $RoleDefinitionId,
+        [Parameter(Mandatory)][string] $RoleName
+    )
 
-    $roleDefinitionId = '62e90394-69f5-4237-9190-012177145e10'
     $filter = [Uri]::EscapeDataString("principalId eq '$UserId' and roleDefinitionId eq '$roleDefinitionId' and directoryScopeId eq '/'")
     $existing = Invoke-Graph GET "roleManagement/directory/roleAssignments?`$filter=$filter"
     if (@($existing.value).Count -eq 0) {
         Invoke-Graph POST 'roleManagement/directory/roleAssignments' @{
             principalId = $UserId
-            roleDefinitionId = $roleDefinitionId
+            roleDefinitionId = $RoleDefinitionId
             directoryScopeId = '/'
         } | Out-Null
+        Write-Host "Assigned $RoleName to user $UserId."
+    }
+}
+
+function Revoke-EmergencyUserSessions {
+    param([Parameter(Mandatory)][object[]] $Users)
+
+    foreach ($user in $Users) {
+        $result = Invoke-Graph POST "users/$($user.id)/revokeSignInSessions"
+        if ($result.value -ne $true) {
+            throw "Microsoft Graph did not confirm session revocation for $($user.userPrincipalName)."
+        }
+        Write-Host "Revoked existing sign-in sessions for $($user.userPrincipalName)."
     }
 }
 
@@ -473,6 +491,7 @@ function Invoke-TapOnboarding {
         return
     }
 
+    $createdTaps = [Collections.Generic.List[object]]::new()
     try {
         $currentTap = Invoke-Graph GET 'policies/authenticationMethodsPolicy/authenticationMethodConfigurations/TemporaryAccessPass' -Beta
         $target = [pscustomobject]@{
@@ -491,22 +510,72 @@ function Invoke-TapOnboarding {
         } -Beta | Out-Null
 
         if (-not (Test-Interactive)) {
-            Write-Warning 'TAP policy was configured, but TAP values cannot be emitted in a noninteractive run. Create reusable two-hour TAPs manually and register at least two passkeys per emergency user.'
-            return
+            throw 'TAP onboarding requires an interactive terminal because each pass is shown once. Rerun interactively, or disable TAP only after preparing phishing-resistant authentication separately.'
         }
 
-        foreach ($user in $Users) {
-            $tap = Invoke-Graph POST "users/$($user.id)/authentication/temporaryAccessPassMethods" @{
-                lifetimeInMinutes = 120
-                isUsableOnce = $false
-            } -Beta
-            Write-Host "Temporary Access Pass for $($user.userPrincipalName) (shown once): $($tap.temporaryAccessPass)"
+        try {
+            foreach ($user in $Users) {
+                $tap = Invoke-Graph POST "users/$($user.id)/authentication/temporaryAccessPassMethods" @{
+                    lifetimeInMinutes = 120
+                    isUsableOnce = $false
+                } -Beta
+                $createdTaps.Add([pscustomobject]@{
+                    UserId = $user.id
+                    UserPrincipalName = $user.userPrincipalName
+                    MethodId = $tap.id
+                })
+                Write-Host "Temporary Access Pass for $($user.userPrincipalName) (shown once): $($tap.temporaryAccessPass)"
+            }
+            Write-Host ''
+            Write-Host 'Register at least one passkey for every emergency account now; two separately stored passkeys per account are strongly recommended.'
+            Write-Host 'Open https://mysignins.microsoft.com/security-info in a private browser session for each account.'
+            Read-Host 'After passkey registration is complete for every account, press Enter to verify' | Out-Null
+            foreach ($user in $Users) {
+                $methods = Invoke-Graph GET "users/$($user.id)/authentication/fido2Methods"
+                if (@($methods.value).Count -eq 0) {
+                    throw "No passkey (FIDO2) is registered for $($user.userPrincipalName). Register one, then rerun 'azd up'."
+                }
+                Write-Host "Verified $(@($methods.value).Count) passkey(s) for $($user.userPrincipalName)."
+            }
         }
-        Write-Host 'Register at least two passkeys for each emergency account before considering onboarding complete.'
+        finally {
+            $cleanupErrors = [Collections.Generic.List[string]]::new()
+            foreach ($createdTap in $createdTaps) {
+                try {
+                    Invoke-Graph DELETE "users/$($createdTap.UserId)/authentication/temporaryAccessPassMethods/$($createdTap.MethodId)"
+                    Write-Host "Removed the onboarding TAP for $($createdTap.UserPrincipalName)."
+                }
+                catch {
+                    $cleanupErrors.Add("$($createdTap.UserPrincipalName): $($_.Exception.Message)")
+                }
+            }
+            if ($cleanupErrors.Count -gt 0) {
+                throw "One or more onboarding TAPs could not be removed: $($cleanupErrors -join '; ')"
+            }
+        }
     }
     catch {
-        Write-Warning "TAP onboarding could not be completed: $($_.Exception.Message)"
-        Write-Warning 'Core provisioning remains valid. Grant the required delegated Graph consent, enable the Temporary Access Pass policy for the emergency group, create a reusable 2-hour TAP for each account, and register at least two passkeys per account.'
+        throw "TAP and passkey onboarding did not complete, so privileged roles were not assigned. $($_.Exception.Message)"
+    }
+}
+
+function Confirm-AuthenticationReady {
+    param([Parameter(Mandatory)][object[]] $Users)
+
+    if ($env:AZD_AUTHENTICATION_READY -eq 'true') {
+        return
+    }
+    if (-not (Test-Interactive)) {
+        throw 'Authentication readiness must be confirmed before privileged roles are assigned. Register phishing-resistant authentication, then set AZD_AUTHENTICATION_READY=true and rerun.'
+    }
+    Write-Host ''
+    Write-Warning 'TAP onboarding was skipped. Privileged roles will not be assigned until phishing-resistant authentication is ready.'
+    foreach ($user in $Users) {
+        Write-Host "  $($user.userPrincipalName)"
+    }
+    $confirmation = Read-Host 'Type ready only after every listed account has a tested passkey or certificate'
+    if ($confirmation.Trim() -ne 'ready') {
+        throw "Authentication readiness was not confirmed. Complete authentication setup, then rerun 'azd up'."
     }
 }
 
@@ -517,10 +586,12 @@ if ($Phase -in 'All', 'Identities') {
             Resolve-EmergencyUser 1
             Resolve-EmergencyUser 2
         )
+        if ($env:AZD_ENABLE_LIMITED_EMERGENCY_ACCOUNT -eq 'true') {
+            $users += Resolve-EmergencyUser 3
+        }
         $group = Resolve-EmergencyGroup -Users $users
         foreach ($user in $users) {
             Add-DirectoryObjectMember "groups/$($group.id)/members" $user.id
-            Ensure-GlobalAdministrator $user.id
         }
 
         $administrativeUnit = Resolve-AdministrativeUnit
@@ -549,12 +620,45 @@ if ($Phase -in 'All', 'Workload') {
         Ensure-FunctionApiRoleAssignment $env:AZURE_PLAYBOOK_PRINCIPAL_ID
     }
 
-    if ($env:AZD_ENABLE_TAP_POLICY -eq 'true') {
+    if ($env:AZD_MANAGE_EMERGENCY_IDENTITIES -eq 'true') {
         $users = @(
             Invoke-Graph GET "users/$($env:AZD_EMERGENCY_USER1_ID)?`$select=id,userPrincipalName"
             Invoke-Graph GET "users/$($env:AZD_EMERGENCY_USER2_ID)?`$select=id,userPrincipalName"
         )
-        Invoke-TapOnboarding -Users $users -GroupId $env:AZD_EMERGENCY_GROUP_ID
+        if ($env:AZD_ENABLE_LIMITED_EMERGENCY_ACCOUNT -eq 'true') {
+            $users += Invoke-Graph GET "users/$($env:AZD_EMERGENCY_USER3_ID)?`$select=id,userPrincipalName"
+        }
+
+        $remediation = Invoke-EmergencyAccessRemediation `
+            -EmergencyAccountsGroupObjectId $env:AZD_EMERGENCY_GROUP_ID `
+            -SkipManagedIdentityConnection
+        Write-Host "Conditional Access reconciliation completed: $($remediation.policiesUpdated) updated, $($remediation.policiesAlreadyExcluded) already protected."
+        $currentUserFingerprint = (@($users.id | Sort-Object) -join ',')
+        if ($env:AZD_ONBOARDED_EMERGENCY_USER_IDS -ne $currentUserFingerprint) {
+            if ($env:AZD_ENABLE_TAP_POLICY -eq 'true') {
+                Invoke-TapOnboarding -Users $users -GroupId $env:AZD_EMERGENCY_GROUP_ID
+            }
+            else {
+                Confirm-AuthenticationReady -Users $users
+            }
+            Revoke-EmergencyUserSessions -Users $users
+            Set-AzdValue AZD_ONBOARDED_EMERGENCY_USER_IDS $currentUserFingerprint
+        }
+
+        foreach ($user in $users | Select-Object -First 2) {
+            Ensure-DirectoryRoleAssignment -UserId $user.id `
+                -RoleDefinitionId '62e90394-69f5-4237-9190-012177145e10' `
+                -RoleName 'Global Administrator'
+        }
+        if ($env:AZD_ENABLE_LIMITED_EMERGENCY_ACCOUNT -eq 'true') {
+            $limitedUser = $users[2]
+            Ensure-DirectoryRoleAssignment -UserId $limitedUser.id `
+                -RoleDefinitionId 'b1be1c3e-b65d-4f19-8427-f6fa0d97feb9' `
+                -RoleName 'Conditional Access Administrator'
+            Ensure-DirectoryRoleAssignment -UserId $limitedUser.id `
+                -RoleDefinitionId '0526716b-113d-4c15-b2c8-68e3c22b9f80' `
+                -RoleName 'Authentication Policy Administrator'
+        }
     }
 }
 Write-Host "Tenant bootstrap phase '$Phase' completed."

--- a/scripts/Bootstrap-Tenant.ps1
+++ b/scripts/Bootstrap-Tenant.ps1
@@ -14,6 +14,9 @@ function Test-Interactive {
 }
 
 function Connect-ProjectGraph {
+    if (-not (Get-Command Connect-MgGraph -ErrorAction SilentlyContinue)) {
+        throw "Microsoft.Graph.Authentication is required. Install it with 'Install-Module Microsoft.Graph.Authentication -Scope CurrentUser', then run 'azd up' again."
+    }
     $scopes = [Collections.Generic.List[string]]::new()
     if ($env:AZD_MANAGE_EMERGENCY_IDENTITIES -eq 'true') {
         @(

--- a/scripts/Remove-TenantObjects.ps1
+++ b/scripts/Remove-TenantObjects.ps1
@@ -93,6 +93,14 @@ $objects = @(
         CurrentId = $env:AZD_EMERGENCY_USER2_ID
         OwnedId = $env:AZD_OWNED_EMERGENCY_USER2_ID
         Uri = 'https://graph.microsoft.com/v1.0/users'
+    },
+    @{
+        Ownership = 'AZD_OWNED_EMERGENCY_USER3_ID'
+        CurrentName = 'AZD_EMERGENCY_USER3_ID'
+        UpnName = 'AZD_EMERGENCY_USER3_UPN'
+        CurrentId = $env:AZD_EMERGENCY_USER3_ID
+        OwnedId = $env:AZD_OWNED_EMERGENCY_USER3_ID
+        Uri = 'https://graph.microsoft.com/v1.0/users'
     }
 )
 

--- a/scripts/Validate-Environment.ps1
+++ b/scripts/Validate-Environment.ps1
@@ -3,14 +3,29 @@ param()
 
 $ErrorActionPreference = 'Stop'
 $allowedModes = @(
-    'automation-scheduled',
     'function-scheduled',
+    'automation-scheduled',
     'logicapp-scheduled',
     'sentinel-function'
 )
 
 function Test-Interactive {
     return -not ($env:CI -or $env:AZD_NON_INTERACTIVE -eq 'true' -or [Console]::IsInputRedirected)
+}
+
+function Set-AzdValue {
+    param(
+        [Parameter(Mandatory)]
+        [string] $Name,
+        [Parameter(Mandatory)]
+        [string] $Value
+    )
+
+    & azd env set $Name $Value | Out-Null
+    if ($LASTEXITCODE -ne 0) {
+        throw "Unable to persist environment value for $Name."
+    }
+    [Environment]::SetEnvironmentVariable($Name, $Value)
 }
 
 function Set-AzdDefault {
@@ -22,12 +37,61 @@ function Set-AzdDefault {
     )
 
     if (-not [Environment]::GetEnvironmentVariable($Name)) {
-        & azd env set $Name $Value | Out-Null
-        if ($LASTEXITCODE -ne 0) {
-            throw "Unable to persist default value for $Name."
-        }
-        [Environment]::SetEnvironmentVariable($Name, $Value)
+        Set-AzdValue -Name $Name -Value $Value
     }
+}
+
+function Clear-AzdValue {
+    param([Parameter(Mandatory)][string] $Name)
+
+    & azd env set $Name '' | Out-Null
+    if ($LASTEXITCODE -ne 0) {
+        throw "Unable to clear environment value $Name."
+    }
+    [Environment]::SetEnvironmentVariable($Name, $null)
+}
+
+function Read-RequiredInput {
+    param([Parameter(Mandatory)][string] $Prompt)
+
+    $value = Read-Host $Prompt
+    if (-not $value) {
+        throw "$Prompt is required. Run 'azd up' again to continue setup."
+    }
+    return $value.Trim()
+}
+
+function Read-MenuSelection {
+    param(
+        [Parameter(Mandatory)][string] $Prompt,
+        [Parameter(Mandatory)][string[]] $Options
+    )
+
+    for ($index = 0; $index -lt $Options.Count; $index++) {
+        Write-Host "  $($index + 1). $($Options[$index])"
+    }
+    $selection = Read-Host $Prompt
+    if ($selection -notmatch '^\d+$' -or
+        [int]$selection -lt 1 -or [int]$selection -gt $Options.Count) {
+        throw "$Prompt must be a number from 1 through $($Options.Count). Run 'azd up' again to continue setup."
+    }
+    return [int]$selection
+}
+
+function Read-WorkspaceConfiguration {
+    param(
+        [Parameter(Mandatory)][string] $Prefix,
+        [Parameter(Mandatory)][string] $DisplayName
+    )
+
+    Write-Host "Configure the existing $DisplayName workspace."
+    $subscriptionId = Read-Host "Subscription ID [$($env:AZURE_SUBSCRIPTION_ID)]"
+    if (-not $subscriptionId) {
+        $subscriptionId = $env:AZURE_SUBSCRIPTION_ID
+    }
+    Set-AzdValue -Name "${Prefix}_SUBSCRIPTION_ID" -Value $subscriptionId.Trim()
+    Set-AzdValue -Name "${Prefix}_RESOURCE_GROUP" -Value (Read-RequiredInput "$DisplayName workspace resource group")
+    Set-AzdValue -Name "${Prefix}_NAME" -Value (Read-RequiredInput "$DisplayName workspace name")
 }
 
 function Assert-GuidValue {
@@ -39,25 +103,36 @@ function Assert-GuidValue {
     }
 }
 
+$guidedSetup = (Test-Interactive) -and (
+    -not $env:AZD_DEPLOYMENT_MODE -or $env:AZD_GUIDED_SETUP_ACTIVE -eq 'true'
+)
+if ($guidedSetup -and $env:AZD_GUIDED_SETUP_ACTIVE -ne 'true') {
+    Set-AzdValue AZD_GUIDED_SETUP_ACTIVE 'true'
+}
 if (-not $env:AZD_DEPLOYMENT_MODE) {
     if (-not (Test-Interactive)) {
         throw "AZD_DEPLOYMENT_MODE is required. Allowed values: $($allowedModes -join ', ')."
     }
 
-    Write-Host 'Choose one deployment mode:'
-    for ($index = 0; $index -lt $allowedModes.Count; $index++) {
-        Write-Host "  $($index + 1). $($allowedModes[$index])"
-    }
-    $selection = Read-Host 'Selection'
-    if ($selection -notmatch '^[1-4]$') {
-        throw 'Deployment mode selection must be a number from 1 through 4.'
-    }
-    $env:AZD_DEPLOYMENT_MODE = $allowedModes[[int]$selection - 1]
-    & azd env set AZD_DEPLOYMENT_MODE $env:AZD_DEPLOYMENT_MODE | Out-Null
+    Write-Host ''
+    Write-Host 'Emergency access setup'
+    Write-Host 'Choose how Conditional Access exclusions will be maintained:'
+    $selection = Read-MenuSelection 'Deployment mode' @(
+        'Scheduled Azure Function (recommended for most organizations)',
+        'Azure Automation runbook',
+        'Scheduled Logic App',
+        'Microsoft Sentinel detection and targeted Function'
+    )
+    $env:AZD_DEPLOYMENT_MODE = $allowedModes[$selection - 1]
+    Set-AzdValue AZD_DEPLOYMENT_MODE $env:AZD_DEPLOYMENT_MODE
 }
 
 if ($env:AZD_DEPLOYMENT_MODE -notin $allowedModes) {
     throw "Unsupported AZD_DEPLOYMENT_MODE '$($env:AZD_DEPLOYMENT_MODE)'. Allowed values: $($allowedModes -join ', ')."
+}
+if ($env:AZD_DEPLOYMENT_MODE -in 'function-scheduled', 'sentinel-function' -and
+    -not (Get-Command func -ErrorAction SilentlyContinue)) {
+    throw "Azure Functions Core Tools v4 is required for '$($env:AZD_DEPLOYMENT_MODE)'. Install it, then run 'azd up' again."
 }
 if ($env:AZD_PROVISIONED_MODE -and $env:AZD_PROVISIONED_MODE -ne $env:AZD_DEPLOYMENT_MODE) {
     throw "This azd environment is locked to provisioned mode '$($env:AZD_PROVISIONED_MODE)'. Run 'azd down' before changing AZD_DEPLOYMENT_MODE, or use a new azd environment."
@@ -113,6 +188,108 @@ if (-not $env:AZD_AUTOMATION_START_TIME) {
     Set-AzdDefault AZD_AUTOMATION_START_TIME (
         [DateTimeOffset]::UtcNow.AddMinutes(15).ToString('yyyy-MM-ddTHH:mm:sszzz')
     )
+}
+
+if ($guidedSetup) {
+    Write-Host ''
+    Write-Host 'Choose how emergency identities will be prepared:'
+    $identitySelection = Read-MenuSelection 'Identity setup' @(
+        'Create and configure two new cloud-only emergency accounts (recommended)',
+        'Use existing accounts and ensure group membership and Global Administrator assignments',
+        'Use externally managed accounts and do not modify their identities or roles'
+    )
+
+    if ($identitySelection -eq 1) {
+        Set-AzdValue AZD_MANAGE_EMERGENCY_IDENTITIES 'true'
+        foreach ($name in 'AZD_EMERGENCY_USER1_ID', 'AZD_EMERGENCY_USER1_UPN', 'AZD_EMERGENCY_USER2_ID', 'AZD_EMERGENCY_USER2_UPN', 'AZD_EMERGENCY_GROUP_ID') {
+            Clear-AzdValue $name
+        }
+        $domain = Read-RequiredInput 'Verified Entra domain for the new accounts (for example, contoso.onmicrosoft.com)'
+        if ($domain -match '[@\s]' -or $domain -notmatch '\.') {
+            throw 'Enter a verified domain name without @, such as contoso.onmicrosoft.com.'
+        }
+        Set-AzdValue AZD_EMERGENCY_DOMAIN $domain
+    }
+    elseif ($identitySelection -eq 2) {
+        Set-AzdValue AZD_MANAGE_EMERGENCY_IDENTITIES 'true'
+        foreach ($number in 1, 2) {
+            $reference = Read-RequiredInput "Emergency account $number UPN or object ID"
+            $parsedId = [guid]::Empty
+            if ([guid]::TryParse($reference, [ref]$parsedId)) {
+                Clear-AzdValue "AZD_EMERGENCY_USER${number}_UPN"
+                Set-AzdValue "AZD_EMERGENCY_USER${number}_ID" $reference
+            }
+            else {
+                Clear-AzdValue "AZD_EMERGENCY_USER${number}_ID"
+                Set-AzdValue "AZD_EMERGENCY_USER${number}_UPN" $reference
+            }
+        }
+        $existingGroupId = Read-Host 'Existing emergency group object ID (leave blank to create one)'
+        if ($existingGroupId) {
+            Set-AzdValue AZD_EMERGENCY_GROUP_ID $existingGroupId.Trim()
+        }
+        else {
+            Clear-AzdValue AZD_EMERGENCY_GROUP_ID
+        }
+    }
+    else {
+        Set-AzdValue AZD_MANAGE_EMERGENCY_IDENTITIES 'false'
+        Clear-AzdValue AZD_EMERGENCY_USER1_UPN
+        Clear-AzdValue AZD_EMERGENCY_USER2_UPN
+        Set-AzdValue AZD_EMERGENCY_GROUP_ID (Read-RequiredInput 'Externally managed emergency group object ID')
+        Set-AzdValue AZD_EMERGENCY_USER1_ID (Read-RequiredInput 'Emergency account 1 object ID')
+        Set-AzdValue AZD_EMERGENCY_USER2_ID (Read-RequiredInput 'Emergency account 2 object ID')
+        Set-AzdValue AZD_ENABLE_TAP_POLICY 'false'
+    }
+
+    if ($identitySelection -ne 3) {
+        Write-Host ''
+        Write-Host 'Temporary Access Pass (TAP) provides the one-time credential needed to register passkeys.'
+        $tapSelection = Read-MenuSelection 'TAP onboarding' @(
+            'Enable TAP onboarding and show each pass once (recommended)',
+            'Skip TAP changes and configure authentication methods separately'
+        )
+        Set-AzdValue AZD_ENABLE_TAP_POLICY $(if ($tapSelection -eq 1) { 'true' } else { 'false' })
+    }
+
+    Write-Host ''
+    Write-Host 'Choose emergency-account use notifications. Existing Entra log ingestion is required.'
+    $alertSelection = Read-MenuSelection 'Alerting' @(
+        'Azure Monitor email from SigninLogs',
+        'Microsoft Sentinel incidents and a Teams channel message',
+        'Both Azure Monitor email and Sentinel/Teams',
+        'Configure alerting later'
+    )
+    $enableSignIn = $alertSelection -in 1, 3
+    $enableSentinelActivity = $alertSelection -in 2, 3
+    Set-AzdValue AZD_ENABLE_SIGNIN_ALERTS $(if ($enableSignIn) { 'true' } else { 'false' })
+    Set-AzdValue AZD_ENABLE_SENTINEL_ACTIVITY_ALERTS $(if ($enableSentinelActivity) { 'true' } else { 'false' })
+    if ($alertSelection -eq 4) {
+        Write-Warning 'Emergency-account use will not be monitored by this deployment until alerting is configured.'
+    }
+
+    if ($env:AZD_DEPLOYMENT_MODE -eq 'sentinel-function' -or $enableSentinelActivity) {
+        Read-WorkspaceConfiguration -Prefix 'AZD_SENTINEL_WORKSPACE' -DisplayName 'Sentinel'
+    }
+    if ($enableSignIn) {
+        if ($env:AZD_DEPLOYMENT_MODE -eq 'sentinel-function' -or $enableSentinelActivity) {
+            Write-Host 'The configured Sentinel workspace will also be used for SigninLogs.'
+        }
+        else {
+            Read-WorkspaceConfiguration -Prefix 'AZD_SIGNIN_LOG_WORKSPACE' -DisplayName 'SigninLogs'
+        }
+        Set-AzdValue AZD_SIGNIN_ALERT_EMAIL (Read-RequiredInput 'Email address for critical sign-in alerts')
+    }
+
+    Write-Host ''
+    Write-Host 'Setup choices are saved in the current azd environment.'
+    Write-Host "  Remediation: $($env:AZD_DEPLOYMENT_MODE)"
+    Write-Host "  Identity management: $($env:AZD_MANAGE_EMERGENCY_IDENTITIES)"
+    Write-Host "  TAP onboarding: $($env:AZD_ENABLE_TAP_POLICY)"
+    Write-Host "  Azure Monitor email: $($env:AZD_ENABLE_SIGNIN_ALERTS)"
+    Write-Host "  Sentinel and Teams: $($env:AZD_ENABLE_SENTINEL_ACTIVITY_ALERTS)"
+    Set-AzdValue AZD_GUIDED_SETUP_ACTIVE 'false'
+    Write-Host 'Continuing with tenant validation and deployment.'
 }
 if ($env:AZD_DEPLOYMENT_MODE -eq 'automation-scheduled') {
     $resourceGroupName = if ($env:AZURE_RESOURCE_GROUP) {

--- a/scripts/Validate-Environment.ps1
+++ b/scripts/Validate-Environment.ps1
@@ -179,7 +179,9 @@ Set-AzdDefault AZD_SCHEDULE_FREQUENCY 'Hour'
 Set-AzdDefault AZD_AUTOMATION_TIME_ZONE 'Etc/UTC'
 Set-AzdDefault AZD_MANAGE_EMERGENCY_IDENTITIES 'true'
 Set-AzdDefault AZD_USE_RESTRICTED_AU 'true'
+Set-AzdDefault AZD_ENABLE_LIMITED_EMERGENCY_ACCOUNT 'false'
 Set-AzdDefault AZD_ENABLE_TAP_POLICY 'false'
+Set-AzdDefault AZD_AUTHENTICATION_READY 'false'
 Set-AzdDefault AZD_ENABLE_SIGNIN_ALERTS 'false'
 Set-AzdDefault AZD_ENABLE_SENTINEL_ACTIVITY_ALERTS 'false'
 Set-AzdDefault AZD_TEST_SENTINEL_NOTIFICATION_DELIVERY 'false'
@@ -201,7 +203,7 @@ if ($guidedSetup) {
 
     if ($identitySelection -eq 1) {
         Set-AzdValue AZD_MANAGE_EMERGENCY_IDENTITIES 'true'
-        foreach ($name in 'AZD_EMERGENCY_USER1_ID', 'AZD_EMERGENCY_USER1_UPN', 'AZD_EMERGENCY_USER2_ID', 'AZD_EMERGENCY_USER2_UPN', 'AZD_EMERGENCY_GROUP_ID') {
+        foreach ($name in 'AZD_EMERGENCY_USER1_ID', 'AZD_EMERGENCY_USER1_UPN', 'AZD_EMERGENCY_USER2_ID', 'AZD_EMERGENCY_USER2_UPN', 'AZD_EMERGENCY_USER3_ID', 'AZD_EMERGENCY_USER3_UPN', 'AZD_EMERGENCY_GROUP_ID') {
             Clear-AzdValue $name
         }
         $domain = Read-RequiredInput 'Verified Entra domain for the new accounts (for example, contoso.onmicrosoft.com)'
@@ -244,12 +246,38 @@ if ($guidedSetup) {
 
     if ($identitySelection -ne 3) {
         Write-Host ''
+        $limitedSelection = Read-MenuSelection 'Limited recovery account' @(
+            'Do not add a third account (recommended for the standard Microsoft design)',
+            'Add a third account for Conditional Access and authentication-policy recovery'
+        )
+        Set-AzdValue AZD_ENABLE_LIMITED_EMERGENCY_ACCOUNT $(if ($limitedSelection -eq 2) { 'true' } else { 'false' })
+        if ($limitedSelection -eq 2 -and $identitySelection -eq 2) {
+            $reference = Read-RequiredInput 'Limited emergency account UPN or object ID'
+            $parsedId = [guid]::Empty
+            if ([guid]::TryParse($reference, [ref]$parsedId)) {
+                Clear-AzdValue AZD_EMERGENCY_USER3_UPN
+                Set-AzdValue AZD_EMERGENCY_USER3_ID $reference
+            }
+            else {
+                Clear-AzdValue AZD_EMERGENCY_USER3_ID
+                Set-AzdValue AZD_EMERGENCY_USER3_UPN $reference
+            }
+        }
+        elseif ($limitedSelection -eq 1) {
+            Clear-AzdValue AZD_EMERGENCY_USER3_ID
+            Clear-AzdValue AZD_EMERGENCY_USER3_UPN
+        }
+
+        Write-Host ''
         Write-Host 'Temporary Access Pass (TAP) provides the one-time credential needed to register passkeys.'
         $tapSelection = Read-MenuSelection 'TAP onboarding' @(
             'Enable TAP onboarding and show each pass once (recommended)',
             'Skip TAP changes and configure authentication methods separately'
         )
         Set-AzdValue AZD_ENABLE_TAP_POLICY $(if ($tapSelection -eq 1) { 'true' } else { 'false' })
+    }
+    else {
+        Set-AzdValue AZD_ENABLE_LIMITED_EMERGENCY_ACCOUNT 'false'
     }
 
     Write-Host ''
@@ -285,6 +313,7 @@ if ($guidedSetup) {
     Write-Host 'Setup choices are saved in the current azd environment.'
     Write-Host "  Remediation: $($env:AZD_DEPLOYMENT_MODE)"
     Write-Host "  Identity management: $($env:AZD_MANAGE_EMERGENCY_IDENTITIES)"
+    Write-Host "  Limited recovery account: $($env:AZD_ENABLE_LIMITED_EMERGENCY_ACCOUNT)"
     Write-Host "  TAP onboarding: $($env:AZD_ENABLE_TAP_POLICY)"
     Write-Host "  Azure Monitor email: $($env:AZD_ENABLE_SIGNIN_ALERTS)"
     Write-Host "  Sentinel and Teams: $($env:AZD_ENABLE_SENTINEL_ACTIVITY_ALERTS)"
@@ -329,7 +358,7 @@ if ($env:AZD_DEPLOYMENT_MODE -eq 'automation-scheduled') {
     }
 }
 
-foreach ($booleanName in 'AZD_MANAGE_EMERGENCY_IDENTITIES', 'AZD_USE_RESTRICTED_AU', 'AZD_ENABLE_TAP_POLICY', 'AZD_ENABLE_SIGNIN_ALERTS', 'AZD_ENABLE_SENTINEL_ACTIVITY_ALERTS', 'AZD_TEST_SENTINEL_NOTIFICATION_DELIVERY') {
+foreach ($booleanName in 'AZD_MANAGE_EMERGENCY_IDENTITIES', 'AZD_USE_RESTRICTED_AU', 'AZD_ENABLE_LIMITED_EMERGENCY_ACCOUNT', 'AZD_ENABLE_TAP_POLICY', 'AZD_AUTHENTICATION_READY', 'AZD_ENABLE_SIGNIN_ALERTS', 'AZD_ENABLE_SENTINEL_ACTIVITY_ALERTS', 'AZD_TEST_SENTINEL_NOTIFICATION_DELIVERY') {
     $value = [Environment]::GetEnvironmentVariable($booleanName)
     if ($value -notin 'true', 'false') {
         throw "$booleanName must be 'true' or 'false'."
@@ -523,6 +552,7 @@ if ($env:AZD_ENABLE_SIGNIN_ALERTS -eq 'true') {
 foreach ($guidName in @(
     'AZD_EMERGENCY_USER1_ID',
     'AZD_EMERGENCY_USER2_ID',
+    'AZD_EMERGENCY_USER3_ID',
     'AZD_EMERGENCY_GROUP_ID',
     'AZD_ADMINISTRATIVE_UNIT_ID'
 )) {
@@ -540,6 +570,9 @@ if ($env:AZD_MANAGE_EMERGENCY_IDENTITIES -eq 'false') {
     }
     if ($env:AZD_ENABLE_TAP_POLICY -eq 'true') {
         throw 'AZD_ENABLE_TAP_POLICY cannot be true when AZD_MANAGE_EMERGENCY_IDENTITIES=false.'
+    }
+    if ($env:AZD_ENABLE_LIMITED_EMERGENCY_ACCOUNT -eq 'true') {
+        throw 'The optional limited emergency account is only supported when AZD_MANAGE_EMERGENCY_IDENTITIES=true.'
     }
 }
 
@@ -592,6 +625,13 @@ if ($env:AZD_DEPLOYMENT_MODE -eq 'sentinel-function' -or $env:AZD_ENABLE_SENTINE
 
 $user1Missing = -not $env:AZD_EMERGENCY_USER1_ID -and -not $env:AZD_EMERGENCY_USER1_UPN
 $user2Missing = -not $env:AZD_EMERGENCY_USER2_ID -and -not $env:AZD_EMERGENCY_USER2_UPN
+$user3Missing = -not $env:AZD_EMERGENCY_USER3_ID -and -not $env:AZD_EMERGENCY_USER3_UPN
+if ($env:AZD_ENABLE_LIMITED_EMERGENCY_ACCOUNT -eq 'true' -and $user3Missing -and -not $env:AZD_EMERGENCY_DOMAIN) {
+    throw 'The limited emergency account requires AZD_EMERGENCY_USER3_ID, AZD_EMERGENCY_USER3_UPN, or AZD_EMERGENCY_DOMAIN.'
+}
+if ($env:AZD_MANAGE_EMERGENCY_IDENTITIES -eq 'true' -and ($user1Missing -or $user2Missing) -and $env:AZD_ENABLE_TAP_POLICY -ne 'true') {
+    throw 'Creating emergency accounts requires AZD_ENABLE_TAP_POLICY=true so usable phishing-resistant authentication is registered before roles are assigned.'
+}
 if ($env:AZD_MANAGE_EMERGENCY_IDENTITIES -eq 'true' -and
     ($user1Missing -or $user2Missing) -and -not $env:AZD_EMERGENCY_DOMAIN) {
     throw 'Set AZD_EMERGENCY_DOMAIN when either emergency user needs to be created.'

--- a/tests/Documentation.Tests.ps1
+++ b/tests/Documentation.Tests.ps1
@@ -1,0 +1,48 @@
+Describe 'Administrator documentation' {
+    BeforeAll {
+        $repoRoot = Resolve-Path "$PSScriptRoot\.."
+        $readme = Get-Content "$repoRoot\README.md" -Raw
+        $catalog = Get-Content "$repoRoot\.azd\catalog.json" -Raw | ConvertFrom-Json
+    }
+
+    It 'keeps the root quickstart to init and up' {
+        (Get-Content "$repoRoot\README.md").Count | Should -BeLessOrEqual 150
+        $readme | Should -Match 'azd init --template nathanmcnulty/azd-emergency-access\s+azd up'
+        @($catalog.quickstartCommands) | Should -Be @(
+            'azd init --template nathanmcnulty/azd-emergency-access',
+            'azd up'
+        )
+    }
+
+    It 'links every focused administrator guide' {
+        foreach ($path in @(
+            'docs/deployment-modes.md',
+            'docs/identity-and-authentication.md',
+            'docs/conditional-access-remediation.md',
+            'docs/alerting-and-notifications.md',
+            'docs/configuration.md',
+            'docs/operations.md',
+            'docs/development.md'
+        )) {
+            $readme | Should -Match ([regex]::Escape("($path)"))
+            Test-Path "$repoRoot\$($path.Replace('/', '\'))" | Should -BeTrue
+        }
+    }
+
+    It 'contains no broken relative Markdown links' {
+        $markdownFiles = Get-ChildItem $repoRoot -Recurse -Filter *.md -File |
+            Where-Object { $_.FullName -notmatch '[\\/]\.git[\\/]' }
+        foreach ($file in $markdownFiles) {
+            $content = Get-Content $file.FullName -Raw
+            foreach ($match in [regex]::Matches($content, '\[[^\]]+\]\(([^)]+)\)')) {
+                $target = $match.Groups[1].Value
+                if ($target -match '^(https?://|mailto:|#)') {
+                    continue
+                }
+                $relativePath = ($target -split '#', 2)[0]
+                $resolved = Join-Path $file.DirectoryName ([uri]::UnescapeDataString($relativePath))
+                Test-Path $resolved | Should -BeTrue -Because "$($file.FullName) links to $target"
+            }
+        }
+    }
+}

--- a/tests/Lifecycle.Wiring.Tests.ps1
+++ b/tests/Lifecycle.Wiring.Tests.ps1
@@ -17,6 +17,7 @@ Describe 'Lifecycle security wiring' {
         $tenantGuards = Get-Content "$PSScriptRoot\..\scripts\Tenant.Guards.psm1" -Raw
         $logicApp = Get-Content "$PSScriptRoot\..\infra\modes\logicapp-scheduled.bicep" -Raw
         $sentinelBicep = Get-Content "$PSScriptRoot\..\infra\modes\sentinel-function.bicep" -Raw
+        $remediation = Get-Content "$PSScriptRoot\..\src\functions\shared\EmergencyAccess.Remediation.psm1" -Raw
     }
 
     It 'reconciles a v2 API audience role and service principal' {
@@ -40,6 +41,7 @@ Describe 'Lifecycle security wiring' {
         $parameters | Should -Match 'AZD_EMERGENCY_GROUP_ID='
         $parameters | Should -Match 'AZD_EMERGENCY_USER1_ID='
         $parameters | Should -Match 'AZD_EMERGENCY_USER2_ID='
+        $parameters | Should -Match 'AZD_EMERGENCY_USER3_ID='
         $validate | Should -Match 'az group exists'
         $validate | Should -Match 'Set-AzdDefault AZURE_TENANT_ID \$subscriptionTenantId'
         $mainBicep | Should -Match "param emergencyAccessGroupObjectId string = ''"
@@ -63,17 +65,43 @@ Describe 'Lifecycle security wiring' {
         $validate | Should -Match 'AZD_MANAGE_EMERGENCY_IDENTITIES=false requires AZD_EMERGENCY_GROUP_ID'
         $validate | Should -Match 'Alerting with externally managed emergency identities requires AZD_EMERGENCY_USER1_ID and AZD_EMERGENCY_USER2_ID'
         $validate | Should -Match 'AZD_ENABLE_TAP_POLICY cannot be true when AZD_MANAGE_EMERGENCY_IDENTITIES=false'
-        $identityGuard = $bootstrap.IndexOf("if (`$env:AZD_MANAGE_EMERGENCY_IDENTITIES -eq 'true')")
+        $identityPhase = $bootstrap.IndexOf("if (`$Phase -in 'All', 'Identities')")
+        $identityGuard = $bootstrap.IndexOf("if (`$env:AZD_MANAGE_EMERGENCY_IDENTITIES -eq 'true')", $identityPhase)
+        $workloadGuard = $bootstrap.LastIndexOf("if (`$env:AZD_MANAGE_EMERGENCY_IDENTITIES -eq 'true')")
         $resolveUser = $bootstrap.LastIndexOf('Resolve-EmergencyUser 1')
-        $globalAdmin = $bootstrap.LastIndexOf('Ensure-GlobalAdministrator $user.id')
+        $globalAdmin = $bootstrap.LastIndexOf("-RoleName 'Global Administrator'")
         $identityGuard | Should -BeGreaterOrEqual 0
         $resolveUser | Should -BeGreaterThan $identityGuard
-        $globalAdmin | Should -BeGreaterThan $resolveUser
+        $workloadGuard | Should -BeGreaterThan $resolveUser
+        $globalAdmin | Should -BeGreaterThan $workloadGuard
         $bootstrap | Should -Match "\}[\r\n ]+Resolve-SentinelServicePrincipal[\r\n ]+Ensure-FunctionAuthApplication"
         $tapGuard = $bootstrap.LastIndexOf("if (`$env:AZD_ENABLE_TAP_POLICY -eq 'true')")
         $tapInvocation = $bootstrap.LastIndexOf('Invoke-TapOnboarding -Users $users')
-        $tapGuard | Should -BeGreaterThan $identityGuard
+        $tapGuard | Should -BeGreaterThan $workloadGuard
         $tapInvocation | Should -BeGreaterThan $tapGuard
+    }
+
+    It 'hardens managed accounts before assigning permanent roles' {
+        $ca = $bootstrap.LastIndexOf('Invoke-EmergencyAccessRemediation')
+        $revoke = $bootstrap.LastIndexOf('Revoke-EmergencyUserSessions -Users')
+        $roles = $bootstrap.LastIndexOf("-RoleName 'Global Administrator'")
+        $ca | Should -BeGreaterOrEqual 0
+        $revoke | Should -BeGreaterThan $ca
+        $roles | Should -BeGreaterThan $revoke
+        $bootstrap | Should -Match 'User\.RevokeSessions\.All'
+        $bootstrap | Should -Match 'authentication/fido2Methods'
+        $bootstrap | Should -Match 'authentication/temporaryAccessPassMethods/\$\(\$createdTap\.MethodId\)'
+        $bootstrap | Should -Match 'One or more onboarding TAPs could not be removed'
+        $bootstrap | Should -Match 'AZD_ONBOARDED_EMERGENCY_USER_IDS'
+        $remediation | Should -Match ([regex]::Escape("'None' -in `$includeUsers"))
+    }
+
+    It 'supports a supplemental lower-privilege emergency account' {
+        $validate | Should -Match "Set-AzdDefault AZD_ENABLE_LIMITED_EMERGENCY_ACCOUNT 'false'"
+        $bootstrap | Should -Match 'Resolve-EmergencyUser 3'
+        $bootstrap | Should -Match 'b1be1c3e-b65d-4f19-8427-f6fa0d97feb9'
+        $bootstrap | Should -Match '0526716b-113d-4c15-b2c8-68e3c22b9f80'
+        $bootstrap | Should -Match "-RoleName 'Authentication Policy Administrator'"
     }
 
     It 'cleans owned Sentinel rules even after a deployment mode change' {
@@ -158,6 +186,7 @@ Describe 'Lifecycle security wiring' {
         $cleanup | Should -Match 'excludeGroups = \$remainingGroups'
         $cleanup | Should -Match 'Remove-ConditionalAccessGroupReferences -GroupId \$object\.OwnedId[\s\S]+Invoke-MgGraphRequest -Method DELETE'
         $cleanup | Should -Match 'Connect-MgGraph'
+        $cleanup | Should -Match 'AZD_OWNED_EMERGENCY_USER3_ID'
         $cleanup | Should -Match 'Connect-MgGraph -NoWelcome'
         $cleanup | Should -Not -Match 'Connect-MgGraph[\s\S]{0,150}-Scopes'
         $cleanup | Should -Not -Match 'az account get-access-token'

--- a/tests/Lifecycle.Wiring.Tests.ps1
+++ b/tests/Lifecycle.Wiring.Tests.ps1
@@ -48,6 +48,16 @@ Describe 'Lifecycle security wiring' {
         }
     }
 
+    It 'provides a resumable first-run administrator wizard' {
+        $validate | Should -Match 'AZD_GUIDED_SETUP_ACTIVE'
+        $validate | Should -Match "Scheduled Azure Function \(recommended for most organizations\)"
+        $validate | Should -Match 'Choose how emergency identities will be prepared'
+        $validate | Should -Match 'Temporary Access Pass \(TAP\) provides the one-time credential'
+        $validate | Should -Match 'Choose emergency-account use notifications'
+        $validate | Should -Match 'Azure Functions Core Tools v4 is required'
+        $validate | Should -Match "Set-AzdValue AZD_GUIDED_SETUP_ACTIVE 'false'"
+    }
+
     It 'supports externally managed emergency identities without privileged identity mutations' {
         $validate | Should -Match "Set-AzdDefault AZD_MANAGE_EMERGENCY_IDENTITIES 'true'"
         $validate | Should -Match 'AZD_MANAGE_EMERGENCY_IDENTITIES=false requires AZD_EMERGENCY_GROUP_ID'

--- a/tests/Sentinel.Activity.Alert.Tests.ps1
+++ b/tests/Sentinel.Activity.Alert.Tests.ps1
@@ -39,6 +39,8 @@ Describe 'Optional Sentinel emergency activity alerting' {
         $rules | Should -Match 'TargetUserId = tostring\(TargetResource.id\)'
         $rules | Should -Match "aggregationKind: 'AlertPerResult'"
         ($rules | Select-String -Pattern 'createIncident: true' -AllMatches).Matches.Count | Should -Be 3
+        $rules | Should -Match "param emergencyUser3ObjectId string = ''"
+        $rules | Should -Match '\$\{emergencyUser3ObjectId\}'
     }
 
     It 'posts an adaptive card and optionally sends mail through an existing Outlook connection' {

--- a/tests/Signin.Alert.Tests.ps1
+++ b/tests/Signin.Alert.Tests.ps1
@@ -11,10 +11,12 @@ Describe 'Optional emergency sign-in alerting' {
         $main | Should -Match "module signInAlerting .* = if \(enableSignInAlerts == 'true'\)"
         $parameters | Should -Match 'AZD_EMERGENCY_USER1_ID='
         $parameters | Should -Match 'AZD_EMERGENCY_USER2_ID='
+        $parameters | Should -Match 'AZD_EMERGENCY_USER3_ID='
         $parameters | Should -Match 'AZD_SIGNIN_LOG_WORKSPACE_SUBSCRIPTION_ID='
         $main | Should -Match 'scope: resourceGroup\(signInLogWorkspaceSubscriptionId, signInLogWorkspaceResourceGroup\)'
         $alerting | Should -Match '@minLength\(1\)\s*param emergencyUser1ObjectId string'
         $alerting | Should -Match '@minLength\(1\)\s*param emergencyUser2ObjectId string'
+        $alerting | Should -Match "param emergencyUser3ObjectId string = ''"
     }
 
     It 'alerts on every successful or failed sign-in record for the emergency users' {


### PR DESCRIPTION
## Summary
- replace the root README with a short `azd init` / `azd up` administrator quickstart and focused component documentation
- add a resumable first-run wizard for identity, remediation, alerting, and guided Teams setup
- harden onboarding so Conditional Access is reconciled before roles, passkeys are verified, temporary passes are removed, and bootstrap sessions are revoked
- add an optional third recovery account with Conditional Access Administrator and Authentication Policy Administrator, including group/AU membership, alerts, and ownership-aware cleanup

## Validation
- 52/52 Pester tests
- PowerShell parser validation across all scripts and modules
- Bicep v0.42.1 build
- generated ARM template parity in a clean detached worktree
- `git diff --check`

## Design note
The third account supplements the two permanent Global Administrator emergency accounts recommended by Microsoft; it does not replace either one.